### PR TITLE
fix(external-domain-nonauth): add unautoritative external domain name

### DIFF
--- a/src/emailpro/domain/add/emailpro-domain-add.controller.js
+++ b/src/emailpro/domain/add/emailpro-domain-add.controller.js
@@ -132,13 +132,6 @@ angular.module('Module.emailpro.controllers').controller('EmailProAddDomainContr
   $scope.checkDomain = function () {
     if ($scope.model.domainType === $scope.nonOvhDomain) {
       $scope.model.srvParam = false;
-      $rootScope.$broadcast('wizard-goToStep', 3);
-    }
-  };
-
-  $scope.checkDomainType = function () {
-    if ($scope.model.domainType === $scope.nonOvhDomain) {
-      $rootScope.$broadcast('wizard-goToStep', 1);
     }
   };
 

--- a/src/emailpro/domain/add/emailpro-domain-add.html
+++ b/src/emailpro/domain/add/emailpro-domain-add.html
@@ -148,8 +148,7 @@
         </div>
 
         <div data-wizard-step
-             data-wizard-step-valid="model.type"
-             data-wizard-step-on-previous="checkDomainType">
+             data-wizard-step-valid="model.type">
 
             <p data-ng-if="model.type === 'AUTHORITATIVE'"
                data-ng-bind-html="tr('exchange_tab_domain_add_step2_auth_intro', model.displayName)"></p>


### PR DESCRIPTION
## Allow user to add non authoritative domains


### Description of the Change

add wizard steps to enable adding of unauth domain name
domain name which is not ovh to have option

### Benefits
Helps add non authoritative external domain names

### Possible Drawbacks

None

### Applicable Issues

MFRWW-307
