### PR TITLE
chore(i18n): retrieve missing translations from exchange

### DIFF
--- a/src/emailpro/account/add/emailpro-account-add.controller.js
+++ b/src/emailpro/account/add/emailpro-account-add.controller.js
@@ -55,7 +55,7 @@ angular.module('Module.emailpro.controllers')
             if (!$scope.containsSamAccountNameLabel) {
               $scope.containsSamAccountNameLabel = $scope
                 .tr(
-                  'exchange_ACTION_update_account_step1_password_contains_samaccount_name',
+                  'emailpro_ACTION_update_account_step1_password_contains_samaccount_name',
                   [selectedAccount.samaccountName],
                 );
             }
@@ -75,8 +75,8 @@ angular.module('Module.emailpro.controllers')
     $scope.getPasswordTooltip = function () {
       if ($scope.newAccountOptions) {
         return $scope.newAccountOptions.passwordComplexityEnabled
-          ? $scope.tr('exchange_ACTION_update_account_step1_complex_password_tooltip', [$scope.newAccountOptions.minPasswordLength])
-          : $scope.tr('exchange_ACTION_update_account_step1_simple_password_tooltip', [$scope.newAccountOptions.minPasswordLength]);
+          ? $scope.tr('emailpro_ACTION_update_account_step1_complex_password_tooltip', [$scope.newAccountOptions.minPasswordLength])
+          : $scope.tr('emailpro_ACTION_update_account_step1_simple_password_tooltip', [$scope.newAccountOptions.minPasswordLength]);
       }
       return null;
     };
@@ -109,16 +109,16 @@ angular.module('Module.emailpro.controllers')
 
         $scope.passwordTooltip = $scope.newAccountOptions.passwordComplexityEnabled
           ? $scope.tr(
-            'exchange_ACTION_update_account_step1_complex_password_tooltip',
+            'emailpro_ACTION_update_account_step1_complex_password_tooltip',
             [$scope.newAccountOptions.minPasswordLength],
           )
           : $scope.tr(
-            'exchange_ACTION_update_account_step1_simple_password_tooltip',
+            'emailpro_ACTION_update_account_step1_simple_password_tooltip',
             [$scope.newAccountOptions.minPasswordLength],
           );
       }, (failure) => {
         $scope.resetAction();
-        $scope.setMessage($scope.tr('exchange_ACTION_add_account_option_fail'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_ACTION_add_account_option_fail'), failure.data);
       });
     };
 
@@ -152,7 +152,7 @@ angular.module('Module.emailpro.controllers')
       $scope.accountToAdd.login = $scope.accountToAdd.login.toLowerCase();
 
       EmailPro.addEmailProAccount($stateParams.productId, $scope.accountToAdd).then(() => {
-        $scope.setMessage($scope.tr('exchange_ACTION_add_account_success_message'), { status: 'success' });
+        $scope.setMessage($scope.tr('emailpro_ACTION_add_account_success_message'), { status: 'success' });
       }, (failure) => {
         $scope.setMessage($scope.tr('emailpro_ACTION_add_account_error_message'), failure.data);
       });
@@ -195,7 +195,7 @@ angular.module('Module.emailpro.controllers')
         $scope.previewOrder = data;
         $scope.url = data.url;
       }, (failure) => {
-        $scope.setMessage($scope.tr('exchange_ACTION_order_accounts_step2_error_message'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_ACTION_order_accounts_step2_error_message'), failure.data);
         $scope.resetAction();
       });
     };
@@ -213,7 +213,7 @@ angular.module('Module.emailpro.controllers')
           return orderAvailable;
         });
       }, (failure) => {
-        $scope.setMessage($scope.tr('exchange_ACTION_order_accounts_step1_loading_error'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_ACTION_order_accounts_step1_loading_error'), failure.data);
         $scope.resetAction();
       });
     };

--- a/src/emailpro/account/add/emailpro-account-add.html
+++ b/src/emailpro/account/add/emailpro-account-add.html
@@ -16,7 +16,7 @@
                 <div class="form-group"
                      data-ng-class="{ 'has-error': emailProAddAccountForm.login.$dirty && (emailProAddAccountForm.login.$invalid || takenEmailError) }">
                     <label class="col-md-12 control-label text-left required" for="login"
-                           data-i18n-static="exchange_ACTION_add_account_step1_email_label"></label>
+                           data-i18n-static="emailpro_ACTION_add_account_step1_email_label"></label>
                     <div class="col-md-12">
                         <div class="input-group">
                             <input type="text" class="form-control" id="login" name="login"
@@ -32,7 +32,7 @@
                             </select>
                         </div>
                         <small class="help-block"
-                               data-i18n-static="exchange_tab_ALIAS_taken_error_message"
+                               data-i18n-static="emailpro_tab_ALIAS_taken_error_message"
                                data-ng-if="takenEmailError">
                         </small>
                         <small class="help-block"
@@ -43,17 +43,17 @@
                 </div>
                 <div class="form-group" data-ng-if="newAccountOptions.availableTypes.length > 1" >
                     <label class="control-label col-md-3" for="accountLicense"
-                           data-i18n-static="exchange_ACTION_update_account_step1_type_label"></label>
+                           data-i18n-static="emailpro_ACTION_update_account_step1_type_label"></label>
                     <div class=" col-md-9">
                         <select class="form-control" id="accountLicense" name="accountLicense" required
-                                data-ng-options="tr('exchange_ACTION_update_account_step1_type_' + type) for type in newAccountOptions.availableTypes"
+                                data-ng-options="tr('emailpro_ACTION_update_account_step1_type_' + type) for type in newAccountOptions.availableTypes"
                                 data-ng-model="accountToAdd.accountLicense">
                         </select>
                     </div>
                 </div>
                 <div class="form-group">
                     <label class="control-label col-md-3" for="firstName"
-                           data-i18n-static="exchange_ACTION_add_account_step1_first_name_label"></label>
+                           data-i18n-static="emailpro_ACTION_add_account_step1_first_name_label"></label>
                     <div class="col-md-9">
                         <input type="text" class="form-control" id="firstName" max="64"
                                data-ng-model="accountToAdd.firstName"
@@ -62,7 +62,7 @@
                 </div>
                 <div class="form-group">
                     <label class="control-label col-md-3" for="lastName"
-                           data-i18n-static="exchange_ACTION_add_account_step1_last_name_label"></label>
+                           data-i18n-static="emailpro_ACTION_add_account_step1_last_name_label"></label>
                     <div class="col-md-9">
                         <input type="text" class="form-control" id="lastName" max="64"
                                data-ng-model="accountToAdd.lastName"
@@ -71,7 +71,7 @@
                 </div>
                 <div class="form-group">
                     <label class="control-label col-md-3" for="displayName"
-                           data-i18n-static="exchange_ACTION_add_account_step1_display_name_label"></label>
+                           data-i18n-static="emailpro_ACTION_add_account_step1_display_name_label"></label>
                     <div class="col-md-9">
                         <input type="text" class="form-control" id="displayName"
                                data-ng-model="accountToAdd.displayName"
@@ -81,7 +81,7 @@
                 <div class="form-group"
                      data-ng-class="{ 'has-error': simplePasswordFlag || containsNameFlag || containsSamAccountNameFlag }">
                     <label for="password" class="control-label col-md-3 required"
-                           data-i18n-static="exchange_ACTION_add_account_step1_password_label"></label>
+                           data-i18n-static="emailpro_ACTION_add_account_step1_password_label"></label>
                     <div class="col-md-9">
                         <input type="password" class="form-control" id="password" placeholder="**********" required
                                data-ng-model="accountToAdd.password"
@@ -89,7 +89,7 @@
                                data-uib-tooltip="{{passwordTooltip}}">
                         <span class="help-block"
                               data-ng-if="simplePasswordFlag"
-                              data-i18n-static="exchange_ACTION_update_account_step1_password_weak"></span>
+                              data-i18n-static="emailpro_ACTION_update_account_step1_password_weak"></span>
                         <span class="help-block"
                               data-ng-if="containsNameFlag"
                               data-i18n-static="emailpro_ACTION_update_account_step1_password_contains_name"></span>
@@ -101,7 +101,7 @@
                 <div class="form-group"
                      data-ng-class="{ 'has-error': differentPasswordFlag || showConfirmPwdError }">
                     <label for="passwordConfirm" class="control-label col-md-3 required"
-                           data-i18n-static="exchange_ACTION_add_account_step1_password_confirmation_label"></label>
+                           data-i18n-static="emailpro_ACTION_add_account_step1_password_confirmation_label"></label>
                     <div class="col-md-9">
                         <input type="password" class="form-control" id="passwordConfirm" placeholder="**********" required
                                data-ng-model="accountToAdd.passwordConfirmation"
@@ -109,50 +109,50 @@
                                data-ng-change="setPasswordsFlag(accountToAdd)">
                         <span class="help-block"
                               data-ng-if="differentPasswordFlag"
-                              data-i18n-static="exchange_ACTION_update_account_step1_password_different"></span>
+                              data-i18n-static="emailpro_ACTION_update_account_step1_password_different"></span>
                         <span class="help-block"
                               data-ng-if="showConfirmPwdError"
-                              data-i18n-static="exchange_tab_ACCOUNTS_pwderror"></span>
+                              data-i18n-static="emailpro_tab_ACCOUNTS_pwderror"></span>
                     </div>
                 </div>
                 <div class="checkbox">
                     <label>
                         <input type="checkbox"
                                data-ng-model="valid.legalWarning">
-                        <span data-ng-bind-html="tr('exchange_ACTION_add_account_legal_warning')"></span>
+                        <span data-ng-bind-html="tr('emailpro_ACTION_add_account_legal_warning')"></span>
                     </label>
                 </div>
             </form>
 
             <div data-wizard-step-help>
                 <h3 data-i18n-static="emailpro_ACTION_add_account_helpwizard_title"></h3>
-                <h4 data-i18n-static="exchange_ACTION_add_account_helpwizard_password_title"></h4>
+                <h4 data-i18n-static="emailpro_ACTION_add_account_helpwizard_password_title"></h4>
                 <p data-ng-if="newAccountOptions.passwordComplexityEnabled"
-                   data-ng-bind-html="tr('exchange_ACTION_add_account_helpwizard_password', [newAccountOptions.minPasswordLength])"></p>
+                   data-ng-bind-html="tr('emailpro_ACTION_add_account_helpwizard_password', [newAccountOptions.minPasswordLength])"></p>
                 <p data-ng-hide="newAccountOptions.passwordComplexityEnabled"
-                   data-ng-bind-html="tr('exchange_ACTION_add_account_helpwizard_password_simple', [newAccountOptions.minPasswordLength])"></p>
+                   data-ng-bind-html="tr('emailpro_ACTION_add_account_helpwizard_password_simple', [newAccountOptions.minPasswordLength])"></p>
             </div>
         </div>
 
         <div data-wizard-step>
-            <p data-i18n-static="exchange_ACTION_add_account_step2_confirmation_intro" ></p>
+            <p data-i18n-static="emailpro_ACTION_add_account_step2_confirmation_intro" ></p>
 
             <dl class="dl-horizontal">
-                <dt data-i18n-static="exchange_ACTION_add_account_step2_email_label"></dt>
+                <dt data-i18n-static="emailpro_ACTION_add_account_step2_email_label"></dt>
                 <dd data-ng-bind-template="{{accountToAdd.login.toLowerCase()}}@{{accountToAdd.completeDomain.displayName}}"></dd>
 
                 <div data-ng-if="newAccountOptions.availableTypes.length > 1" >
-                    <dt data-i18n-static="exchange_ACTION_update_account_step1_type_label"></dt>
-                    <dd data-ng-bind="tr('exchange_ACTION_update_account_step1_type_' + accountToAdd.accountLicense)"></dd>
+                    <dt data-i18n-static="emailpro_ACTION_update_account_step1_type_label"></dt>
+                    <dd data-ng-bind="tr('emailpro_ACTION_update_account_step1_type_' + accountToAdd.accountLicense)"></dd>
                 </div>
 
-                <dt data-i18n-static="exchange_ACTION_add_account_step2_first_name_label" data-ng-if="accountToAdd.firstName"></dt>
+                <dt data-i18n-static="emailpro_ACTION_add_account_step2_first_name_label" data-ng-if="accountToAdd.firstName"></dt>
                 <dd data-ng-if="accountToAdd.firstName" data-ng-bind="accountToAdd.firstName"></dd>
 
-                <dt data-i18n-static="exchange_ACTION_add_account_step2_last_name_label" data-ng-if="accountToAdd.lastName"></dt>
+                <dt data-i18n-static="emailpro_ACTION_add_account_step2_last_name_label" data-ng-if="accountToAdd.lastName"></dt>
                 <dd data-ng-if="accountToAdd.lastName" data-ng-bind="accountToAdd.lastName"></dd>
 
-                <dt data-i18n-static="exchange_ACTION_add_account_step2_display_name_label" data-ng-if="accountToAdd.displayName"></dt>
+                <dt data-i18n-static="emailpro_ACTION_add_account_step2_display_name_label" data-ng-if="accountToAdd.displayName"></dt>
                 <dd data-ng-if="accountToAdd.displayName" data-ng-bind="accountToAdd.displayName"></dd>
             </dl>
         </div>

--- a/src/emailpro/account/alias/add/emailpro-account-alias-add.html
+++ b/src/emailpro/account/alias/add/emailpro-account-alias-add.html
@@ -3,7 +3,7 @@
          data-wizard-bread-crumb
          data-wizard-on-cancel="resetAction"
          data-wizard-on-finish="addAccountAlias"
-         data-wizard-title="i18n.exchange_tab_ALIAS_add_alias_title">
+         data-wizard-title="i18n.emailpro_tab_ALIAS_add_alias_title">
 
         <div data-wizard-step
              data-wizard-step-valid="aliasIsValid()"
@@ -16,9 +16,9 @@
             <div data-ng-if="availableDomains">
                 <div class="form-group" data-ng-class="{'has-error': takenEmailError}">
                     <label class="control-label" for="aliasInput"
-                           data-ng-bind-html="tr('exchange_tab_ALIAS_add_alias_intro', selectedAccount.primaryEmailDisplayName)"></label>
+                           data-ng-bind-html="tr('emailpro_tab_ALIAS_add_alias_intro', selectedAccount.primaryEmailDisplayName)"></label>
                     <div class="input-group">
-                        <input type="text" class="form-control" name="aliasInput" id="aliasInput" placeholder="{{i18n.exchange_tab_ALIAS_add_alias_placeholder}}"
+                        <input type="text" class="form-control" name="aliasInput" id="aliasInput" placeholder="{{i18n.emailpro_tab_ALIAS_add_alias_placeholder}}"
                                data-ng-change="checkTakenEmails()"
                                data-ng-model="model.alias"
                                data-ng-pattern="/^[-_a-zA-z0-9]+((\.|\+)[-_a-zA-Z0-9]+)*$/">
@@ -30,20 +30,20 @@
                         </select>
                     </div>
                     <small class="help-block"
-                           data-i18n-static="exchange_tab_ALIAS_taken_error_message"
+                           data-i18n-static="emailpro_tab_ALIAS_taken_error_message"
                            data-ng-if="takenEmailError"></small>
                 </div>
                 <div class="alert alert-info" role="alert"
-                     data-i18n-static="exchange_tab_ALIAS_add_alias_valid"></div>
+                     data-i18n-static="emailpro_tab_ALIAS_add_alias_valid"></div>
             </div>
         </div>
 
         <div data-wizard-step>
-            <p data-i18n-static="exchange_tab_ALIAS_add_alias_step2_intro"></p>
+            <p data-i18n-static="emailpro_tab_ALIAS_add_alias_step2_intro"></p>
             <dl class="dl-horizontal">
-                <dt data-i18n-static="exchange_tab_ALIAS_add_alias_step2_alias_label"></dt>
+                <dt data-i18n-static="emailpro_tab_ALIAS_add_alias_step2_alias_label"></dt>
                 <dd data-ng-bind-template="{{model.alias}}@{{model.domain.displayName}}"></dd>
-                <dt data-i18n-static="exchange_tab_ALIAS_add_alias_step2_account_label"></dt>
+                <dt data-i18n-static="emailpro_tab_ALIAS_add_alias_step2_account_label"></dt>
                 <dd data-ng-bind="selectedAccount.primaryEmailAddress"></dd>
             </dl>
         </div>

--- a/src/emailpro/account/alias/emailpro-account-alias.controller.js
+++ b/src/emailpro/account/alias/emailpro-account-alias.controller.js
@@ -32,7 +32,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProTabAliasCtrl',
         })
         .catch((failure) => {
           _.set(failure, 'data.type', failure.data.type || 'ERROR');
-          $scope.setMessage($scope.tr('exchange_tab_ALIAS_error_message'), failure.data);
+          $scope.setMessage($scope.tr('emailpro_tab_ALIAS_error_message'), failure.data);
         });
     }
     return null;
@@ -56,7 +56,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProTabAliasCtrl',
       })
       .catch((failure) => {
         _.set(failure, 'data.type', failure.data.type || 'ERROR');
-        $scope.setMessage($scope.tr('exchange_tab_ALIAS_error_message'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_tab_ALIAS_error_message'), failure.data);
       });
   };
 
@@ -106,7 +106,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProAddAccountAlia
         }
       }, (failure) => {
         _.set(failure, 'data.type', failure.data.type || 'ERROR');
-        $scope.setMessage($scope.tr('exchange_tab_ALIAS_domain_loading_failure'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_tab_ALIAS_domain_loading_failure'), failure.data);
         $scope.resetAction();
       });
   };
@@ -125,12 +125,12 @@ angular.module('Module.emailpro.controllers').controller('EmailProAddAccountAlia
     EmailPro
       .addAlias($stateParams.productId, $scope.selectedAccount.primaryEmailAddress, $scope.model)
       .then((data) => {
-        $scope.setMessage($scope.tr('exchange_tab_ALIAS_add_alias_success_message'), { status: 'success' });
+        $scope.setMessage($scope.tr('emailpro_tab_ALIAS_add_alias_success_message'), { status: 'success' });
         return data;
       })
       .catch((failure) => {
         _.set(failure, 'type', failure.type || 'ERROR');
-        $scope.setMessage($scope.tr('exchange_tab_ALIAS_add_alias_error_message'), failure);
+        $scope.setMessage($scope.tr('emailpro_tab_ALIAS_add_alias_error_message'), failure);
       });
   };
 
@@ -152,12 +152,12 @@ angular.module('Module.emailpro.controllers').controller('EmailProRemoveAliasCtr
     EmailPro
       .deleteAlias($stateParams.productId, $scope.account.primaryEmailAddress, $scope.alias.alias)
       .then((data) => {
-        $scope.setMessage($scope.tr('exchange_tab_ALIAS_delete_success_message'), { status: 'success' });
+        $scope.setMessage($scope.tr('emailpro_tab_ALIAS_delete_success_message'), { status: 'success' });
         return data;
       })
       .catch((failure) => {
         _.set(failure, 'type', failure.type || 'ERROR');
-        $scope.setMessage($scope.tr('exchange_tab_ALIAS_delete_error_message'), failure);
+        $scope.setMessage($scope.tr('emailpro_tab_ALIAS_delete_error_message'), failure);
       });
   };
 });
@@ -189,7 +189,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProTabGroupAliasC
         .catch((failure) => {
           $scope.aliasLoading = false;
           _.set(failure, 'type', failure.type || 'ERROR');
-          $scope.setMessage($scope.tr('exchange_tab_ALIAS_error_message'), failure);
+          $scope.setMessage($scope.tr('emailpro_tab_ALIAS_error_message'), failure);
         });
     }
   };
@@ -242,7 +242,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProAddGroupAliasC
         }
       }, (failure) => {
         _.set(failure, 'data.type', failure.data.type || 'ERROR');
-        $scope.setMessage($scope.tr('exchange_tab_ALIAS_domain_loading_failure'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_tab_ALIAS_domain_loading_failure'), failure.data);
         $scope.resetAction();
       });
   };
@@ -265,11 +265,11 @@ angular.module('Module.emailpro.controllers').controller('EmailProAddGroupAliasC
         $scope.model,
       )
       .then(() => {
-        $scope.setMessage($scope.tr('exchange_tab_ALIAS_add_alias_success_message'), { status: 'success' });
+        $scope.setMessage($scope.tr('emailpro_tab_ALIAS_add_alias_success_message'), { status: 'success' });
       })
       .catch((failure) => {
         _.set(failure, 'data.type', failure.data.type || 'ERROR');
-        $scope.setMessage($scope.tr('exchange_tab_ALIAS_add_alias_error_message'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_tab_ALIAS_add_alias_error_message'), failure.data);
       });
   };
 
@@ -295,11 +295,11 @@ angular.module('Module.emailpro.controllers').controller('EmailProRemoveGroupAli
         $scope.alias.alias,
       )
       .then(() => {
-        $scope.setMessage($scope.tr('exchange_tab_ALIAS_delete_success_message'), { status: 'success' });
+        $scope.setMessage($scope.tr('emailpro_tab_ALIAS_delete_success_message'), { status: 'success' });
       })
       .catch((failure) => {
         _.set(failure, 'data.type', failure.data.type || 'ERROR');
-        $scope.setMessage($scope.tr('exchange_tab_ALIAS_delete_error_message'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_tab_ALIAS_delete_error_message'), failure.data);
       });
   };
 });

--- a/src/emailpro/account/alias/emailpro-account-alias.html
+++ b/src/emailpro/account/alias/emailpro-account-alias.html
@@ -2,20 +2,20 @@
     <div class="col-md-9">
 
         <oui-back-button data-on-click="hideAliases()">
-            <span data-i18n-static="exchange_tab_ACCOUNTS_popover_alias"></span>
+            <span data-i18n-static="emailpro_tab_ACCOUNTS_popover_alias"></span>
         </oui-back-button>
 
         <oui-datagrid data-rows-loader="getAliases($config)">
-            <oui-column data-title="tr('exchange_tab_ALIAS_header')" data-property="displayName"></oui-column>
-            <oui-column data-title="tr('exchange_tab_ACCOUNTS_table_status')" data-property="taskPendingId">
+            <oui-column data-title="tr('emailpro_tab_ALIAS_header')" data-property="displayName"></oui-column>
+            <oui-column data-title="tr('emailpro_tab_ACCOUNTS_table_status')" data-property="taskPendingId">
                 <span class="label label-info"
-                      data-i18n-static="exchange_tab_ALIAS_state_TASK_ON_DOING"
+                      data-i18n-static="emailpro_tab_ALIAS_state_TASK_ON_DOING"
                       data-ng-if="$row.taskPendingId"
-                      data-uib-tooltip="{{i18n.exchange_tab_ALIAS_state_TASK_ON_DOING_tooltip}}"
+                      data-uib-tooltip="{{i18n.emailpro_tab_ALIAS_state_TASK_ON_DOING_tooltip}}"
                       data-tooltip-append-to-body="true"></span>
             </oui-column>
             <oui-action-menu data-align="end" data-compact>
-                <oui-action-menu-item data-text="{{i18n.exchange_tab_ALIAS_delete_tooltip}}"
+                <oui-action-menu-item data-text="{{i18n.emailpro_tab_ALIAS_delete_tooltip}}"
                                       data-on-click="deleteAlias($row)"
                                       data-disabled="$row.taskPendingId"></oui-action-menu-item>
             </oui-action-menu>
@@ -24,7 +24,7 @@
 
     <div class="col-md-3 mt-5 mt-lg-0">
         <button class="btn btn-block btn-default" type="button"
-                data-i18n-static="exchange_tab_ALIAS_add_button"
+                data-i18n-static="emailpro_tab_ALIAS_add_button"
                 data-ng-click="addAccountAlias()"
                 data-ng-disabled="selectedAccount.aliases >= aliasMaxLimit">
         </button>

--- a/src/emailpro/account/alias/remove/emailpro-account-alias-remove.html
+++ b/src/emailpro/account/alias/remove/emailpro-account-alias-remove.html
@@ -2,14 +2,14 @@
     <div data-wizard
          data-wizard-on-cancel="resetAction"
          data-wizard-on-finish="submit"
-         data-wizard-title="i18n.exchange_tab_ALIAS_remove_alias_title">
+         data-wizard-title="i18n.emailpro_tab_ALIAS_remove_alias_title">
 
         <div data-wizard-step>
             <p data-i18n-static="emailpro_tab_ALIAS_remove_alias_intro"></p>
             <dl class="dl-horizontal">
-                <dt data-i18n-static="exchange_tab_ALIAS_remove_alias_label"></dt>
+                <dt data-i18n-static="emailpro_tab_ALIAS_remove_alias_label"></dt>
                 <dd data-ng-bind="alias.displayName"></dd>
-                <dt data-i18n-static="exchange_tab_ALIAS_remove_account_label"></dt>
+                <dt data-i18n-static="emailpro_tab_ALIAS_remove_account_label"></dt>
                 <dd data-ng-bind="account.primaryEmailDisplayName"></dd>
             </dl>
         </div>

--- a/src/emailpro/account/delegation/emailpro-account-delegation.controller.js
+++ b/src/emailpro/account/delegation/emailpro-account-delegation.controller.js
@@ -52,16 +52,16 @@ angular.module('Module.emailpro.controllers').controller('EmailProAccountDelegat
 
   const constructResult = function (data) {
     const mainMessage = {
-      OK: $scope.tr('exchange_ACTION_delegation_success_message'),
-      PARTIAL: $scope.tr('exchange_ACTION_delegation_partial_message'),
-      ERROR: $scope.tr('exchange_ACTION_delegation_error_message'),
+      OK: $scope.tr('emailpro_ACTION_delegation_success_message'),
+      PARTIAL: $scope.tr('emailpro_ACTION_delegation_partial_message'),
+      ERROR: $scope.tr('emailpro_ACTION_delegation_error_message'),
     };
     let state = 'OK';
     let errors = 0;
 
     angular.forEach(data, (task) => {
       if (task.status === 'ERROR') {
-        _.set(task, 'message', $scope.tr(`exchange_tab_TASKS_${task.function}`));
+        _.set(task, 'message', $scope.tr(`emailpro_tab_TASKS_${task.function}`));
         _.set(task, 'type', 'ERROR');
         state = 'PARTIAL';
         errors += 1;
@@ -126,7 +126,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProAccountDelegat
       })
       .catch((failure) => {
         $scope.loading = false;
-        $scope.setMessage($scope.tr('exchange_tab_ACCOUNTS_error_message'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_tab_ACCOUNTS_error_message'), failure.data);
       });
   };
 
@@ -146,12 +146,12 @@ angular.module('Module.emailpro.controllers').controller('EmailProAccountDelegat
 
   $scope.updateDelegationRight = function () {
     $scope.resetAction();
-    $scope.setMessage($scope.tr('exchange_ACTION_delegation_doing_message'), { status: 'success' });
+    $scope.setMessage($scope.tr('emailpro_ACTION_delegation_doing_message'), { status: 'success' });
 
     EmailPro.updateAccountDelegationRights($stateParams.productId, getChanges()).then((data) => {
       constructResult(data);
     }, (failure) => {
-      $scope.setMessage($scope.tr('exchange_ACTION_delegation_error_message'), failure.data);
+      $scope.setMessage($scope.tr('emailpro_ACTION_delegation_error_message'), failure.data);
     });
   };
 
@@ -233,7 +233,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProMailingListDel
       })
       .catch((failure) => {
         $scope.loading = false;
-        $scope.setMessage($scope.tr('exchange_tab_GROUPS_error_message'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_tab_GROUPS_error_message'), failure.data);
       });
   };
 
@@ -253,15 +253,15 @@ angular.module('Module.emailpro.controllers').controller('EmailProMailingListDel
 
   $scope.updateDelegationRight = function () {
     $scope.resetAction();
-    $scope.setMessage($scope.tr('exchange_GROUPS_delegation_doing_message'));
+    $scope.setMessage($scope.tr('emailpro_GROUPS_delegation_doing_message'));
 
     EmailPro
       .updateMailingListDelegationRights($stateParams.productId, getChanges())
       .then((data) => {
-        $scope.setMessage($scope.tr('exchange_GROUPS_delegation_success_message'), data);
+        $scope.setMessage($scope.tr('emailpro_GROUPS_delegation_success_message'), data);
       })
       .catch((failure) => {
-        $scope.setMessage($scope.tr('exchange_GROUPS_delegation_error_message'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_GROUPS_delegation_error_message'), failure.data);
       });
   };
 

--- a/src/emailpro/account/delegation/emailpro-account-delegation.html
+++ b/src/emailpro/account/delegation/emailpro-account-delegation.html
@@ -1,7 +1,7 @@
 <div data-ng-controller="EmailProAccountDelegationCtrl">
     <div data-wizard
          data-wizard-bread-crumb
-         data-wizard-title="i18n.exchange_ACTION_delegation_title"
+         data-wizard-title="i18n.emailpro_ACTION_delegation_title"
          data-wizard-on-cancel="resetAction"
          data-wizard-on-finish="updateDelegationRight">
 
@@ -16,7 +16,7 @@
             <div class="text-right mb-3">
                 <form class="form-inline">
                     <div class="input-group">
-                        <input type="text" class="form-control" placeholder="{{i18n.exchange_tab_ACCOUNTS_table_email}}"
+                        <input type="text" class="form-control" placeholder="{{i18n.emailpro_tab_ACCOUNTS_table_email}}"
                                data-ng-disabled="loading"
                                data-ng-model="form.search">
                         <div class="input-group-btn">
@@ -37,20 +37,20 @@
 
             <div class="alert alert-warning" role="alert"
                  data-ng-if="accounts && accounts.list.messages.length > 0 && !loading"
-                 data-i18n-static="exchange_tab_ACCOUNTS_partial">
+                 data-i18n-static="emailpro_tab_ACCOUNTS_partial">
             </div>
 
             <table class="table table-bordered">
                 <thead>
                     <tr>
                         <th scope="col"
-                            data-i18n-static="exchange_ACTION_delegation_step1_email_header"></th>
+                            data-i18n-static="emailpro_ACTION_delegation_step1_email_header"></th>
                         <th scope="col" class="text-center text-wrap"
-                            data-i18n-static="exchange_ACTION_delegation_step1_send_header"></th>
+                            data-i18n-static="emailpro_ACTION_delegation_step1_send_header"></th>
                         <th scope="col" class="text-center text-wrap"
-                            data-i18n-static="exchange_ACTION_delegation_step1_sendOnBehalfTo_header"></th>
+                            data-i18n-static="emailpro_ACTION_delegation_step1_sendOnBehalfTo_header"></th>
                         <th scope="col" class="text-center text-wrap min-width"
-                            data-i18n-static="exchange_ACTION_delegation_step1_full_header"></th>
+                            data-i18n-static="emailpro_ACTION_delegation_step1_full_header"></th>
                     </tr>
                 </thead>
 
@@ -62,7 +62,7 @@
 
                 <tbody data-ng-if="accounts.list.results.length == 0 && accounts.list.messages.length == 0 && !loading">
                     <tr>
-                        <td colspan="4" class="text-center" data-i18n-static="exchange_tab_ACCOUNTS_table_empty"></td>
+                        <td colspan="4" class="text-center" data-i18n-static="emailpro_tab_ACCOUNTS_table_empty"></td>
                     </tr>
                 </tbody>
 
@@ -75,23 +75,23 @@
                             <div data-ng-if="account.sendAsOnDoing || account.sendOnBehalfToOnDoing">
                                 <input type="checkbox" disabled
                                        data-ng-model="account.newSendAsValue"
-                                       data-uib-tooltip="{{i18n.exchange_ACTION_delegation_step1_task_on_doing}}">
+                                       data-uib-tooltip="{{i18n.emailpro_ACTION_delegation_step1_task_on_doing}}">
                             </div>
                             <!-- No task on doing-->
                             <div data-ng-if="!account.sendAsOnDoing || !account.sendOnBehalfToOnDoing">
                                 <!-- Mutual exclusive option (sendOnBehalf) is activated-->
                                 <div data-ng-if="account.sendOnBehalfTo && account.newSendOnBehalfToValue"
-                                     data-uib-tooltip="{{i18n.exchange_ACTION_delegation_sendas_tooltip}}">
+                                     data-uib-tooltip="{{i18n.emailpro_ACTION_delegation_sendas_tooltip}}">
                                     <input type="checkbox" disabled>
                                 </div>
                                 <!-- Mutual exclusive option (sendOnBehalf) will be activated-->
                                 <div data-ng-if="!account.sendOnBehalfTo && account.newSendOnBehalfToValue"
-                                     data-uib-tooltip="{{i18n.exchange_ACTION_delegation_sendas_tooltip}}">
+                                     data-uib-tooltip="{{i18n.emailpro_ACTION_delegation_sendas_tooltip}}">
                                     <input type="checkbox" disabled>
                                 </div>
                                 <!-- Wait until mutual exclusive option (sendOnBehalf) will be deactivated-->
                                 <div data-ng-show="account.sendOnBehalfTo && !account.newSendOnBehalfToValue"
-                                     data-uib-tooltip="{{i18n.exchange_ACTION_delegation_wait_sendas_tooltip}}">
+                                     data-uib-tooltip="{{i18n.emailpro_ACTION_delegation_wait_sendas_tooltip}}">
                                     <input type="checkbox" disabled>
                                 </div>
                                 <!-- Mutual exclusive option (sendOnBehalf) is deactivated-->
@@ -103,7 +103,7 @@
                         <td class="text-center">
                             <!-- A task is on doing (activation or deactivation, sendAs or sendOnBehalf)-->
                             <div data-ng-if="account.sendAsOnDoing || account.sendOnBehalfToOnDoing"
-                                 data-uib-tooltip="{{i18n.exchange_ACTION_delegation_step1_task_on_doing}}">
+                                 data-uib-tooltip="{{i18n.emailpro_ACTION_delegation_step1_task_on_doing}}">
                                 <input type="checkbox" disabled
                                     data-ng-model="account.newSendOnBehalfToValue">
                             </div>
@@ -111,17 +111,17 @@
                             <div data-ng-if="!account.sendAsOnDoing || !account.sendOnBehalfToOnDoing">
                                 <!-- Mutual exclusive option (sendAs) is activated-->
                                 <div data-ng-if="account.sendAs && account.newSendAsValue"
-                                     data-uib-tooltip="{{i18n.exchange_ACTION_delegation_behalf_tooltip}}">
+                                     data-uib-tooltip="{{i18n.emailpro_ACTION_delegation_behalf_tooltip}}">
                                     <input type="checkbox" disabled>
                                 </div>
                                 <!-- Mutual exclusive option (sendAs) will be  activated-->
                                 <div data-ng-if="!account.sendAs && account.newSendAsValue"
-                                     data-uib-tooltip="{{i18n.exchange_ACTION_delegation_behalf_tooltip}}">
+                                     data-uib-tooltip="{{i18n.emailpro_ACTION_delegation_behalf_tooltip}}">
                                     <input type="checkbox" disabled>
                                 </div>
                                 <!-- Wait until mutual exclusive option (sendAs) will be  activated-->
                                 <div data-ng-if="account.sendAs && !account.newSendAsValue"
-                                     data-uib-tooltip="{{i18n.exchange_ACTION_delegation_wait_behalf_tooltip}}">
+                                     data-uib-tooltip="{{i18n.emailpro_ACTION_delegation_wait_behalf_tooltip}}">
                                     <input type="checkbox" disabled>
                                 </div>
                                 <!-- Mutual exclusive option (sendAs) is deactivated-->
@@ -132,7 +132,7 @@
                         </td>
                         <td class="text-center text-nowrap">
                             <div data-ng-if="account.fullAccessOnDoing"
-                                 data-uib-tooltip="{{i18n.exchange_ACTION_delegation_step1_task_on_doing}}">
+                                 data-uib-tooltip="{{i18n.emailpro_ACTION_delegation_step1_task_on_doing}}">
                                 <input type="checkbox"
                                        data-ng-model="account.newFullAccessValue"
                                        data-ng-disabled="'true'">
@@ -147,7 +147,7 @@
                         <td colspan="4">
                             <div class="text-warning">
                                 <span class="icon-warning-sign" aria-hidden="true"></span>
-                                <span data-ng-bind="account.id" data-uib-tooltip="{{tr('exchange_GROUPS_partial_account', [account.message])}}"></span>
+                                <span data-ng-bind="account.id" data-uib-tooltip="{{tr('emailpro_GROUPS_partial_account', [account.message])}}"></span>
                             </div>
                         </td>
                     </tr>
@@ -160,18 +160,18 @@
         </div>
 
         <div data-wizard-step>
-            <p data-ng-bind-html="tr('exchange_ACTION_delegation_step2_intro', [primaryEmailDisplayName])"></p>
+            <p data-ng-bind-html="tr('emailpro_ACTION_delegation_step2_intro', [primaryEmailDisplayName])"></p>
 
             <table class="table table-bordered">
                 <thead>
                     <tr>
-                        <th scope="col" data-i18n-static="exchange_ACTION_delegation_step2_email_header"></th>
+                        <th scope="col" data-i18n-static="emailpro_ACTION_delegation_step2_email_header"></th>
                         <th scope="col" class="text-center"
-                            data-i18n-static="exchange_ACTION_delegation_step2_send_header"></th>
+                            data-i18n-static="emailpro_ACTION_delegation_step2_send_header"></th>
                         <th scope="col" class="text-center"
-                            data-i18n-static="exchange_ACTION_delegation_step2_sendOnBehalfTo_header"></th>
+                            data-i18n-static="emailpro_ACTION_delegation_step2_sendOnBehalfTo_header"></th>
                         <th scope="col" class="text-center"
-                            data-i18n-static="exchange_ACTION_delegation_step2_full_header"></th>
+                            data-i18n-static="emailpro_ACTION_delegation_step2_full_header"></th>
                     </tr>
                 </thead>
 
@@ -180,17 +180,17 @@
                         <th scope="row" data-ng-bind="account.primaryEmailDisplayName"></th>
                         <td class="text-center">
                             <span data-ng-if="account.newSendAsValue"
-                                  data-i18n-static="exchange_ACTION_delegation_step2_right_true"></span>
+                                  data-i18n-static="emailpro_ACTION_delegation_step2_right_true"></span>
                             <span data-ng-if="!account.newSendAsValue"> - </span>
                         </td>
                         <td class="text-center">
                             <span data-ng-if="account.newSendOnBehalfToValue"
-                                  data-i18n-static="exchange_ACTION_delegation_step2_right_true"></span>
+                                  data-i18n-static="emailpro_ACTION_delegation_step2_right_true"></span>
                             <span data-ng-if="!account.newSendOnBehalfToValue"> - </span>
                         </td>
                         <td class="text-center">
                             <span data-ng-if="account.newFullAccessValue"
-                                  data-i18n-static="exchange_ACTION_delegation_step2_right_true"></span>
+                                  data-i18n-static="emailpro_ACTION_delegation_step2_right_true"></span>
                             <span data-ng-if="!account.newFullAccessValue"> - </span>
                         </td>
                     </tr>

--- a/src/emailpro/account/delegation/setting/emailpro-account-delegation-setting.controller.js
+++ b/src/emailpro/account/delegation/setting/emailpro-account-delegation-setting.controller.js
@@ -67,7 +67,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProDelegationSett
       })
       .catch((failure) => {
         $scope.loading = false;
-        $scope.setMessage($scope.tr('exchange_tab_ACCOUNTS_error_message'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_tab_ACCOUNTS_error_message'), failure.data);
       });
   };
 
@@ -83,12 +83,12 @@ angular.module('Module.emailpro.controllers').controller('EmailProDelegationSett
 
   $scope.updateDelegationRight = function () {
     $scope.resetAction();
-    $scope.setMessage($scope.tr('exchange_ACTION_delegation_doing_message'));
+    $scope.setMessage($scope.tr('emailpro_ACTION_delegation_doing_message'));
 
     EmailPro.updateDelegationRight(getChanges()).then((data) => {
-      $scope.setMessage($scope.tr('exchange_ACTION_delegation_success_message'), data);
+      $scope.setMessage($scope.tr('emailpro_ACTION_delegation_success_message'), data);
     }, (failure) => {
-      $scope.setMessage($scope.tr('exchange_ACTION_delegation_error_message'), failure.data);
+      $scope.setMessage($scope.tr('emailpro_ACTION_delegation_error_message'), failure.data);
     });
   };
 

--- a/src/emailpro/account/emailpro-account.controller.js
+++ b/src/emailpro/account/emailpro-account.controller.js
@@ -43,7 +43,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProTabAccountsCtr
           $scope.orderOutlookDisabled = false;
         }
       }, (failure) => {
-        $scope.setMessage($scope.tr('exchange_tab_ACCOUNTS_error_message'), failure);
+        $scope.setMessage($scope.tr('emailpro_tab_ACCOUNTS_error_message'), failure);
       });
 
     EmailPro.getNewAccountOptions($stateParams.productId).then((data) => {
@@ -55,7 +55,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProTabAccountsCtr
     });
   };
 
-  $scope.spamTooltipContent = $scope.tr('exchange_tab_ACCOUNTS_popover_span_text', [
+  $scope.spamTooltipContent = $scope.tr('emailpro_tab_ACCOUNTS_popover_span_text', [
     `#/ticket?serviceName=${$stateParams.productId}`,
   ]);
 
@@ -85,7 +85,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProTabAccountsCtr
         }
       }, (failure) => {
         $scope.loading = false;
-        $scope.setMessage($scope.tr('exchange_tab_ACCOUNTS_error_message'), failure);
+        $scope.setMessage($scope.tr('emailpro_tab_ACCOUNTS_error_message'), failure);
       });
   };
 

--- a/src/emailpro/account/emailpro-account.html
+++ b/src/emailpro/account/emailpro-account.html
@@ -3,12 +3,12 @@
         <div class="col-md-9">
             <div class="alert alert-warning mt-3" role="alert"
                  data-ng-if="accounts && accounts.list.messages.length > 0 && !loading">
-                <strong data-i18n-static="exchange_tab_ACCOUNTS_warning"></strong>
-                <span data-i18n-static="exchange_tab_ACCOUNTS_partial"></span>
+                <strong data-i18n-static="emailpro_tab_ACCOUNTS_warning"></strong>
+                <span data-i18n-static="emailpro_tab_ACCOUNTS_partial"></span>
             </div>
             <div class="pull-left">
-                <strong data-i18n-static="exchange_tab_INFORMATIONS_webmail"></strong> :
-                <a target="_blank" title="{{tr('exchange_tab_INFORMATIONS_webmail')}} ({{tr('exchange_dashboard_new_window')}})"
+                <strong data-i18n-static="emailpro_tab_INFORMATIONS_webmail"></strong> :
+                <a target="_blank" title="{{tr('emailpro_tab_INFORMATIONS_webmail')}} ({{tr('emailpro_dashboard_new_window')}})"
                    data-ng-href="https://{{exchange.hostname}}">
                     <span data-ng-bind="'https://' + exchange.hostname"></span>
                     <span class="fa fa-external-link ml-2" aria-hidden="true"></span>
@@ -25,16 +25,16 @@
                             <select class="oui-select__input"
                                     data-ng-change="setFilter()"
                                     data-ng-model="filterType"
-                                    data-ng-options="tr('exchange_tab_ACCOUNTS_type_' + type) for type in accountTypes">
+                                    data-ng-options="tr('emailpro_tab_ACCOUNTS_type_' + type) for type in accountTypes">
                             </select>
                             <span class="oui-icon oui-icon-chevron-down" aria-hidden="true"></span>
                         </div>
                     </div>
                     <div class="form-group">
                         <label class="sr-only" for="searchAccount"
-                               data-ng-bind="i18n.table_filter + ' ' + i18n.exchange_tab_ACCOUNTS_table_email"></label>
+                               data-ng-bind="i18n.table_filter + ' ' + i18n.emailpro_tab_ACCOUNTS_table_email"></label>
                         <div class="input-group">
-                            <input type="text" class="form-control" id="searchAccount" name="searchAccount" placeholder="{{i18n.exchange_tab_ACCOUNTS_table_email}}"
+                            <input type="text" class="form-control" id="searchAccount" name="searchAccount" placeholder="{{i18n.emailpro_tab_ACCOUNTS_table_email}}"
                                    data-ng-disabled="loading"
                                    data-ng-model="search.value"
                                    data-ng-model-options="{debounce: 1000}">
@@ -56,12 +56,12 @@
                 <table class="table table-hover">
                     <thead>
                         <tr>
-                            <th scope="col" data-i18n-static="exchange_tab_ACCOUNTS_table_email"></th>
-                            <th class="text-center" scope="col" data-i18n-static="exchange_tab_ACCOUNTS_table_type"
+                            <th scope="col" data-i18n-static="emailpro_tab_ACCOUNTS_table_email"></th>
+                            <th class="text-center" scope="col" data-i18n-static="emailpro_tab_ACCOUNTS_table_type"
                                 data-ng-if="(exchange.serverDiagnostic.version === 14 && exchange.offer !== exchangeTypeHosted)"></th>
-                            <th class="text-center" scope="col" data-i18n-static="exchange_tab_ACCOUNTS_table_size"></th>
-                            <th class="text-center" scope="col" data-i18n-static="exchange_tab_ACCOUNTS_table_alias"></th>
-                            <th class="text-center" scope="col" data-i18n-static="exchange_tab_ACCOUNTS_table_status"></th>
+                            <th class="text-center" scope="col" data-i18n-static="emailpro_tab_ACCOUNTS_table_size"></th>
+                            <th class="text-center" scope="col" data-i18n-static="emailpro_tab_ACCOUNTS_table_alias"></th>
+                            <th class="text-center" scope="col" data-i18n-static="emailpro_tab_ACCOUNTS_table_status"></th>
                             <th class="min-width text-center" scope="col"></th>
                         </tr>
                     </thead>
@@ -76,13 +76,13 @@
                         <tr data-ng-if="!search.value">
                             <td class="text-center" colspan="6">
                                 <span data-ng-if="!filterType || filterType === 'ALL'"
-                                      data-i18n-static="exchange_tab_ACCOUNTS_table_empty"></span>
-                                <span data-ng-bind="tr('exchange_tab_ACCOUNTS_table_empty_type_' + filterType)"
+                                      data-i18n-static="emailpro_tab_ACCOUNTS_table_empty"></span>
+                                <span data-ng-bind="tr('emailpro_tab_ACCOUNTS_table_empty_type_' + filterType)"
                                       data-ng-if="filterType && filterType !== 'ALL'"></span>
                             </td>
                         </tr>
                         <tr data-ng-if="search.value">
-                            <td class="text-center" colspan="6" data-i18n-static="exchange_tab_ACCOUNTS_table_empty_search"></td>
+                            <td class="text-center" colspan="6" data-i18n-static="emailpro_tab_ACCOUNTS_table_empty_search"></td>
                         </tr>
                     </tbody>
 
@@ -91,7 +91,7 @@
                             <th scope="row" data-ng-bind="account.primaryEmailDisplayName"></th>
 
                             <td data-ng-if="(exchange.serverDiagnostic.version == 14 && exchange.offer != exchangeTypeHosted)"
-                                data-ng-bind="tr('exchange_tab_ACCOUNTS_type_' + account.accountLicense)"></td>
+                                data-ng-bind="tr('emailpro_tab_ACCOUNTS_type_' + account.accountLicense)"></td>
 
                             <td>
                                 <div class="progress m-0">
@@ -120,11 +120,11 @@
                             <td class="text-center">
                                 <span class="fa fa-hourglass-half text-danger"
                                       data-ng-if="account.state === stateTaskError"
-                                      data-uib-tooltip="{{tr('exchange_tab_ACCOUNTS_state_TASK_ON_ERROR')}}"
+                                      data-uib-tooltip="{{tr('emailpro_tab_ACCOUNTS_state_TASK_ON_ERROR')}}"
                                       data-tooltip-append-to-body="true"></span>
                                 <span class="fa fa-hourglass-half text-info"
                                       data-ng-if="account.state === stateTaskDoing"
-                                      data-uib-tooltip="{{tr('exchange_tab_ACCOUNTS_state_TASK_ON_DOING')}}"
+                                      data-uib-tooltip="{{tr('emailpro_tab_ACCOUNTS_state_TASK_ON_DOING')}}"
                                       data-tooltip-append-to-body="true"></span>
 
                                 <span class="label label-info"
@@ -148,7 +148,7 @@
                                         data-ng-if="account.spamDetected && account.state === stateOk"
                                         data-simplepopover="{{spamTooltipContent}}"
                                         data-simplepopover-single="true"
-                                        data-simplepopover-title="{{tr('exchange_tab_ACCOUNTS_popover_span_title')}}"
+                                        data-simplepopover-title="{{tr('emailpro_tab_ACCOUNTS_popover_span_title')}}"
                                         data-simplepopover-placement="top">
                                 </button>
                             </td>
@@ -161,13 +161,13 @@
                                 </button>
                                 <span class="btn btn-icon"
                                       data-ng-if="noDomainFlag"
-                                      data-uib-tooltip="{{i18n.exchange_tab_ACCOUNTS_menu_account_no_domain_tooltip}}"
+                                      data-uib-tooltip="{{i18n.emailpro_tab_ACCOUNTS_menu_account_no_domain_tooltip}}"
                                       data-tooltip-append-to-body="true">
                                     <span class="oui-icon oui-icon-pen_line oui-icon_small text-muted" aria-hidden="true"></span>
                                 </span>
                                 <button class="btn btn-icon" type="button" title="{{account.primaryEmailDisplayName}} {{i18n.table_manage_entry}}"
                                         data-ng-disabled="!isConfigurable(account)"
-                                        data-uib-tooltip="{{i18n.exchange_tab_ACCOUNTS_menu_account_tooltip}}"
+                                        data-uib-tooltip="{{i18n.emailpro_tab_ACCOUNTS_menu_account_tooltip}}"
                                         data-tooltip-append-to-body="true"
                                         data-linkedpopover="emailpro/account/emailpro-account.popover.html"
                                         data-linkedpopover-placement="left"
@@ -182,7 +182,7 @@
                         <tr data-ng-repeat="account in (accounts.list.messages | orderBy:'id':false) track by $index">
                             <td class="text-center" colspan="6">
                                 <span data-ng-bind="account.primaryEmailAddress"></span> :
-                                <span data-i18n-static="exchange_tab_ACCOUNTS_partial_account"></span>
+                                <span data-i18n-static="emailpro_tab_ACCOUNTS_partial_account"></span>
                             </td>
                         </tr>
                     </tbody>
@@ -202,9 +202,9 @@
             <button class="btn btn-block btn-default" type="button"
                     data-ng-click="newAccount()"
                     data-ng-disabled="addAccountOptionNotAvailable()">
-                <span data-i18n-static="exchange_ACTION_order_accounts_button"
+                <span data-i18n-static="emailpro_ACTION_order_accounts_button"
                       data-ng-if="(exchange.serverDiagnostic.version == 14 && is25g()) || (exchange.serverDiagnostic.version == 14 && exchange.offer == exchangeTypeHosted ) || (exchange.serverDiagnostic.version == 15 && exchange.offer != exchangeTypeDedicated) "></span>
-                <span data-i18n-static="exchange_ACTION_add_account_button"
+                <span data-i18n-static="emailpro_ACTION_add_account_button"
                       data-ng-if="!is25g() && ((exchange.serverDiagnostic.version == 14 && exchange.offer != exchangeTypeHosted) || (exchange.serverDiagnostic.version == 15 && exchange.offer == exchangeTypeDedicated))"></span>
             </button>
         </div>

--- a/src/emailpro/account/emailpro-account.popover.html
+++ b/src/emailpro/account/emailpro-account.popover.html
@@ -1,14 +1,14 @@
 <div data-ng-controller="EmailProToolboxAccountsCtrl" class="popover-menu">
 
     <button class="btn btn-link" type="button"
-            data-i18n-static="exchange_tab_ACCOUNTS_popover_alias"
+            data-i18n-static="emailpro_tab_ACCOUNTS_popover_alias"
             data-ng-class="isDisabled(account)"
             data-ng-click="aliasDisplay(account)"
             data-ng-if="!is25g()">
     </button>
 
 	<button class="btn btn-link" type="button"
-            data-i18n-static="exchange_tab_ACCOUNTS_popover_delegation"
+            data-i18n-static="emailpro_tab_ACCOUNTS_popover_delegation"
             data-ng-class="isDisabled(account)"
             data-ng-click="delegationSettings(account)"
             data-ng-if="!is25g()">

--- a/src/emailpro/account/order/emailpro-account-order.html
+++ b/src/emailpro/account/order/emailpro-account-order.html
@@ -19,7 +19,7 @@
                 <strong data-i18n-static="emailpro_ACTION_order_accounts_step1_intro"></strong>
                 <div class="form-group">
                     <label class="col-md-4 control-label"
-                           data-i18n-static="exchange_ACTION_order_accounts_step1_pay_type"></label>
+                           data-i18n-static="emailpro_ACTION_order_accounts_step1_pay_type"></label>
                     <div class="col-md-8">
                         <div class="oui-radio"
                              data-ng-repeat="orderAvailable in ordersList track by $index">
@@ -29,7 +29,7 @@
                                     data-ng-model="accountsToAdd.duration">
                             <label class="oui-radio__label-container" for="{{'duration'+$index}}">
                                 <span class="oui-radio__label">
-                                    <span data-ng-bind-html="tr('exchange_ACTION_order_accounts_step1_pay_type_' + orderAvailable.duration.duration)"></span>
+                                    <span data-ng-bind-html="tr('emailpro_ACTION_order_accounts_step1_pay_type_' + orderAvailable.duration.duration)"></span>
                                     (<strong>
                                         <span data-ng-if="!showPriceWithTaxOnly"
                                               data-ng-bind="tr('emailpro_ACTION_order_accounts_step1_price', [ orderAvailable.unitaryMonthlyPrice.text, orderAvailable.unitaryMonthlyPriceWithTaxes.text ])">
@@ -48,20 +48,20 @@
                 <div class="form-group"
                      data-ng-class="{ 'has-error' : orderAccountForm.accountNumber.$invalid }">
                     <label class="col-md-4 control-label"
-                           data-i18n-static="exchange_ACTION_order_accounts_step1_number"></label>
+                           data-i18n-static="emailpro_ACTION_order_accounts_step1_number"></label>
                     <div class="col-md-8">
                         <input type="number" class="oui-input oui-input_inline" id="accountNumber" name="accountNumber" min="1" max="100" required
                                data-ng-model="accountsToAdd.accountsNumber"
                                data-ng-pattern="/^\d+$/"
-                               data-uib-tooltip="{{i18n.exchange_ACTION_order_accounts_step1_number_tooltip}}">
+                               data-uib-tooltip="{{i18n.emailpro_ACTION_order_accounts_step1_number_tooltip}}">
                         <span class="help-block"
                               data-ng-if="!orderAccountForm.accountNumber.$valid"
-                              data-i18n-static="exchange_ACTION_order_accounts_step1_number_not_valid"></span>
+                              data-i18n-static="emailpro_ACTION_order_accounts_step1_number_not_valid"></span>
                     </div>
                 </div>
                 <oui-checkbox id="legalWarning"
                     data-model="valid.legalWarning"
-                    data-text="{{::tr('exchange_ACTION_add_account_legal_warning')}}">
+                    data-text="{{::tr('emailpro_ACTION_add_account_legal_warning')}}">
                 </oui-checkbox>
             </form>
         </div>
@@ -73,22 +73,22 @@
             <div class="text-center"
                  data-ng-if="!previewOrder">
                 <oui-spinner></oui-spinner>
-                <div data-i18n-static="exchange_ACTION_order_accounts_step2_loader"></div>
+                <div data-i18n-static="emailpro_ACTION_order_accounts_step2_loader"></div>
             </div>
             <form class="form-horizontal" name="previewOrderForm"
                   data-ng-if="previewOrder">
-                <strong data-i18n-static="exchange_ACTION_order_accounts_step2_intro"></strong>
+                <strong data-i18n-static="emailpro_ACTION_order_accounts_step2_intro"></strong>
                 <div class="form-group">
                     <label class="col-md-4 control-label"
-                           data-i18n-static="exchange_ACTION_order_accounts_step2_pay_type"></label>
+                           data-i18n-static="emailpro_ACTION_order_accounts_step2_pay_type"></label>
                     <div class="col-md-8">
                         <p class="form-control-static"
-                           data-ng-bind="tr('exchange_ACTION_order_accounts_step1_pay_type_' + accountsToAdd.duration)"></p>
+                           data-ng-bind="tr('emailpro_ACTION_order_accounts_step1_pay_type_' + accountsToAdd.duration)"></p>
                     </div>
                 </div>
                 <div class="form-group">
                     <label class="col-md-4 control-label"
-                           data-i18n-static="exchange_ACTION_order_accounts_step2_number"></label>
+                           data-i18n-static="emailpro_ACTION_order_accounts_step2_number"></label>
                     <div class="col-md-8">
                         <p class="form-control-static"
                            data-ng-bind="accountsToAdd.accountsNumber"></p>
@@ -96,10 +96,10 @@
                 </div>
                 <div class="form-group">
                     <label class="col-md-4 control-label"
-                           data-i18n-static="exchange_ACTION_order_accounts_step2_total"></label>
+                           data-i18n-static="emailpro_ACTION_order_accounts_step2_total"></label>
                     <div class="col-md-7">
                         <p class="form-control-static text-danger"
-                           data-ng-bind="tr('exchange_ACTION_order_accounts_step2_price', [previewOrder.prices.withoutTax.text, previewOrder.prices.withTax.text])">
+                           data-ng-bind="tr('emailpro_ACTION_order_accounts_step2_price', [previewOrder.prices.withoutTax.text, previewOrder.prices.withTax.text])">
                         </p>
                     </div>
                 </div>
@@ -110,13 +110,13 @@
              data-wizard-step-valid="url">
             <div class="text-center" data-ng-if="!url">
                 <oui-spinner></oui-spinner>
-                <div data-i18n-static="exchange_ACTION_order_accounts_step3_generation_bc"></div>
+                <div data-i18n-static="emailpro_ACTION_order_accounts_step3_generation_bc"></div>
             </div>
             <div data-ng-if="url">
-                <strong class="d-block mb-3" data-i18n-static="exchange_ACTION_order_accounts_step3_bc"></strong>
-                <p data-i18n-static="exchange_ACTION_order_accounts_step3_continue"></p>
-                <p data-i18n-static="exchange_ACTION_order_accounts_step3_explication2"></p>
-                <em data-i18n-static="exchange_ACTION_order_accounts_step3_explication"></em>
+                <strong class="d-block mb-3" data-i18n-static="emailpro_ACTION_order_accounts_step3_bc"></strong>
+                <p data-i18n-static="emailpro_ACTION_order_accounts_step3_continue"></p>
+                <p data-i18n-static="emailpro_ACTION_order_accounts_step3_explication2"></p>
+                <em data-i18n-static="emailpro_ACTION_order_accounts_step3_explication"></em>
             </div>
         </div>
 

--- a/src/emailpro/account/update/emailpro-account-update.controller.js
+++ b/src/emailpro/account/update/emailpro-account-update.controller.js
@@ -68,10 +68,10 @@ angular.module('Module.emailpro.controllers').controller('EmailProUpdateAccountC
         }
       } else if (messages[0].message === EmailPro.updateAccountAction) {
         updateAccountMessages.PARTIAL = $scope.tr('emailpro_ACTION_update_account_success_message');
-        updateAccountMessages.PARTIAL += ` ${$scope.tr('exchange_ACTION_change_password_account_error_message_linked')}`;
+        updateAccountMessages.PARTIAL += ` ${$scope.tr('emailpro_ACTION_change_password_account_error_message_linked')}`;
       } else {
         updateAccountMessages.PARTIAL = $scope.tr('emailpro_ACTION_change_password_account_success_message');
-        updateAccountMessages.PARTIAL += ` ${$scope.tr('exchange_ACTION_update_account_error_message_linked')}`;
+        updateAccountMessages.PARTIAL += ` ${$scope.tr('emailpro_ACTION_update_account_error_message_linked')}`;
       }
     }
     return updateAccountMessages;
@@ -148,7 +148,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProUpdateAccountC
           && selectedAccount.password.indexOf(selectedAccount.samaccountName) !== -1) {
           if (!$scope.containsSamAccountNameLabel) {
             $scope.containsSamAccountNameLabel = $scope
-              .tr('exchange_ACTION_update_account_step1_password_contains_samaccount_name',
+              .tr('emailpro_ACTION_update_account_step1_password_contains_samaccount_name',
                 [selectedAccount.samaccountName]);
           }
           $scope.containsSamAccountNameFlag = true;
@@ -195,7 +195,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProUpdateAccountC
   };
 
   $scope.getPasswordPlaceholder = function () {
-    return $scope.selectedAccount.canBeConfigured ? $scope.tr('exchange_ACTION_update_account_step1_password_placeholder') : ' ';
+    return $scope.selectedAccount.canBeConfigured ? $scope.tr('emailpro_ACTION_update_account_step1_password_placeholder') : ' ';
   };
 
   $scope.getCompleteDomain = function (domainName) {
@@ -240,12 +240,12 @@ angular.module('Module.emailpro.controllers').controller('EmailProUpdateAccountC
       }
 
       $scope.passwordTooltip = $scope.newAccountOptions.passwordComplexityEnabled
-        ? $scope.tr('exchange_ACTION_update_account_step1_complex_password_tooltip',
+        ? $scope.tr('emailpro_ACTION_update_account_step1_complex_password_tooltip',
           [$scope.newAccountOptions.minPasswordLength])
-        : $scope.tr('exchange_ACTION_update_account_step1_simple_password_tooltip',
+        : $scope.tr('emailpro_ACTION_update_account_step1_simple_password_tooltip',
           [$scope.newAccountOptions.minPasswordLength]);
     }, (failure) => {
-      $scope.setMessage($scope.tr('exchange_ACTION_add_account_option_fail'), failure.data);
+      $scope.setMessage($scope.tr('emailpro_ACTION_add_account_option_fail'), failure.data);
       $scope.resetAction();
     });
   };
@@ -256,7 +256,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProUpdateAccountC
 
   $scope.updateExchangeAccount = function () {
     $scope.resetAction();
-    $scope.setMessage($scope.tr('exchange_dashboard_action_doing'));
+    $scope.setMessage($scope.tr('emailpro_dashboard_action_doing'));
 
     if ($scope.needsUpdate()) {
       EmailPro

--- a/src/emailpro/account/update/emailpro-account-update.html
+++ b/src/emailpro/account/update/emailpro-account-update.html
@@ -24,7 +24,7 @@
                 <div class="form-group"
                      data-ng-class="{ 'has-error': emailProUpdateAccountForm.login.$dirty && (emailProUpdateAccountForm.login.$invalid || takenEmailError) }">
                     <label for="login" class="col-md-12 control-label text-left required"
-                           data-i18n-static="exchange_ACTION_add_account_step1_email_label"></label>
+                           data-i18n-static="emailpro_ACTION_add_account_step1_email_label"></label>
                     <div class="col-md-12">
                         <div class="input-group">
                             <input type="text" class="form-control" id="login" name="login" required
@@ -41,7 +41,7 @@
                             </select>
                         </div>
                         <small class="help-block"
-                               data-i18n-static="exchange_tab_ALIAS_taken_error_message"
+                               data-i18n-static="emailpro_tab_ALIAS_taken_error_message"
                                data-ng-if="takenEmailError">
                         </small>
                         <small class="help-block"
@@ -53,10 +53,10 @@
                 <div class="form-group"
                      data-ng-show="!selectedAccount.is25g && newAccountOptions.availableTypes.length > 1">
                     <label for="accountLicense" class="col-md-3 control-label"
-                           data-i18n-static="exchange_ACTION_update_account_step1_type_label"></label>
+                           data-i18n-static="emailpro_ACTION_update_account_step1_type_label"></label>
                     <div class="col-md-9">
                         <select class="form-control" id="accountLicense" name="accountLicense"
-                                data-ng-options="tr('exchange_ACTION_update_account_step1_type_' + type) for type in newAccountOptions.availableTypes"
+                                data-ng-options="tr('emailpro_ACTION_update_account_step1_type_' + type) for type in newAccountOptions.availableTypes"
                                 data-ng-model="selectedAccount.accountLicense"
                                 data-required>
                         </select>
@@ -64,7 +64,7 @@
                 </div>
                 <div class="form-group">
                     <label for="firstname" class="col-md-3 control-label"
-                           data-i18n-static="exchange_ACTION_update_account_step1_first_name_label"></label>
+                           data-i18n-static="emailpro_ACTION_update_account_step1_first_name_label"></label>
                     <div class="col-md-9">
                         <input type="text" class="form-control" id="firstname" name="firstname" maxlength="64"
                                data-ng-model="selectedAccount.firstName"
@@ -73,7 +73,7 @@
                 </div>
                 <div class="form-group">
                     <label for="lastname" class="col-md-3 control-label"
-                           data-i18n-static="exchange_ACTION_update_account_step1_last_name_label"></label>
+                           data-i18n-static="emailpro_ACTION_update_account_step1_last_name_label"></label>
                     <div class="col-md-9">
                         <input type="text" class="form-control" id="lastname" name="lastname" maxlength="64"
                                data-ng-model="selectedAccount.lastName"
@@ -82,7 +82,7 @@
                 </div>
                 <div class="form-group">
                     <label for="displayname" class="col-md-3 control-label"
-                           data-i18n-static="exchange_ACTION_update_account_step1_display_name_label"></label>
+                           data-i18n-static="emailpro_ACTION_update_account_step1_display_name_label"></label>
                     <div class="col-md-9">
                         <input type="text" class="form-control" id="displayname" name="displayname"
                                data-ng-model="selectedAccount.displayName"
@@ -93,7 +93,7 @@
                      data-ng-class="{ 'has-error': simplePasswordFlag || containsNameFlag || containsSamAccountNameFlag }">
                     <label for="password" class="col-md-3 control-label"
                            data-ng-class="{ 'required': !selectedAccount.canBeConfigured }"
-                           data-i18n-static="exchange_ACTION_update_account_step1_password_label"></label>
+                           data-i18n-static="emailpro_ACTION_update_account_step1_password_label"></label>
                     <div class="col-md-9">
                         <input type="password" class="form-control" id="password" name="password"
                                placeholder="{{getPasswordPlaceholder()}}"
@@ -101,7 +101,7 @@
                                data-ng-change="setPasswordsFlag(selectedAccount)"
                                data-uib-tooltip="{{passwordTooltip}}">
                         <span class="help-block" data-ng-if="simplePasswordFlag"
-                              data-i18n-static="exchange_ACTION_update_account_step1_password_weak"></span>
+                              data-i18n-static="emailpro_ACTION_update_account_step1_password_weak"></span>
                         <span class="help-block" data-ng-if="containsNameFlag"
                              data-i18n-static="emailpro_ACTION_update_account_step1_password_contains_name"></span>
                         <span class="help-block" data-ng-if="containsSamAccountNameFlag"
@@ -112,7 +112,7 @@
                      data-ng-class="{ 'has-error': selectedAccount.passwordConfirmation && differentPasswordFlag }">
                     <label for="passwordConfirmation" class="col-md-3 control-label"
                            data-ng-class="{ 'required': !selectedAccount.canBeConfigured }"
-                           data-i18n-static="exchange_ACTION_update_account_step1_password_confirmation_label"></label>
+                           data-i18n-static="emailpro_ACTION_update_account_step1_password_confirmation_label"></label>
                     <div class="col-md-9">
                         <input type="password" class="form-control" id="passwordConfirmation" name="passwordConfirmation"
                                 placeholder="{{getPasswordPlaceholder()}}"
@@ -121,13 +121,13 @@
                                 data-uib-tooltip="{{passwordTooltip}}">
                         <span class="help-block"
                               data-ng-if="selectedAccount.passwordConfirmation && differentPasswordFlag"
-                              data-i18n-static="exchange_ACTION_update_account_step1_password_different"></span>
+                              data-i18n-static="emailpro_ACTION_update_account_step1_password_different"></span>
                     </div>
                 </div>
                 <div class="form-group"
                      data-ng-show="!selectedAccount.is25g && newAccountOptions && exchange.offer == accountTypeProvider">
                     <label for="quota" class="col-md-3 control-label"
-                           data-i18n-static="exchange_ACTION_update_account_step1_quota_label"></label>
+                           data-i18n-static="emailpro_ACTION_update_account_step1_quota_label"></label>
                     <div class="col-md-9">
                         <select class="form-control w-75 pull-left" id="quota" required
                                 data-ng-options="quota for quota in newAccountOptions.quotaArray"
@@ -141,47 +141,47 @@
             <div data-wizard-step-help>
                 <h3 data-i18n-static="emailpro_ACTION_update_account_helpwizard_title"></h3>
                 <p data-ng-bind-html="tr('emailpro_ACTION_update_account_helpwizard_intro')"></p>
-                <strong data-i18n-static="exchange_ACTION_update_account_helpwizard_password_title"></strong>
+                <strong data-i18n-static="emailpro_ACTION_update_account_helpwizard_password_title"></strong>
                 <p data-ng-show="newAccountOptions.passwordComplexityEnabled"
-                   data-ng-bind-html="tr('exchange_ACTION_update_account_helpwizard_password', [newAccountOptions.minPasswordLength])"></p>
+                   data-ng-bind-html="tr('emailpro_ACTION_update_account_helpwizard_password', [newAccountOptions.minPasswordLength])"></p>
                 <p data-ng-hide="newAccountOptions.passwordComplexityEnabled"
-                   data-ng-bind-html="tr('exchange_ACTION_update_account_helpwizard_password_simple', [newAccountOptions.minPasswordLength])"></p>
+                   data-ng-bind-html="tr('emailpro_ACTION_update_account_helpwizard_password_simple', [newAccountOptions.minPasswordLength])"></p>
             </div>
         </div>
 
         <div data-wizard-step>
-            <p data-i18n-static="exchange_ACTION_update_account_step2_confirmation_intro"></p>
+            <p data-i18n-static="emailpro_ACTION_update_account_step2_confirmation_intro"></p>
             <dl class="dl-horizontal dl-lg">
-                <dt data-i18n-static="exchange_ACTION_update_account_step2_email_label"></dt>
+                <dt data-i18n-static="emailpro_ACTION_update_account_step2_email_label"></dt>
                 <dd data-ng-bind="selectedAccount.login + '@' + selectedAccount.completeDomain.displayName"></dd>
 
                 <div data-ng-if="newAccountOptions.availableTypes.length > 1">
-                    <dt data-i18n-static="exchange_ACTION_update_account_step1_type_label"></dt>
-                    <dd data-ng-bind="tr('exchange_ACTION_update_account_step1_type_' + selectedAccount.accountLicense)"></dd>
+                    <dt data-i18n-static="emailpro_ACTION_update_account_step1_type_label"></dt>
+                    <dd data-ng-bind="tr('emailpro_ACTION_update_account_step1_type_' + selectedAccount.accountLicense)"></dd>
                 </div>
 
-                <dt data-i18n-static="exchange_ACTION_update_account_step2_first_name_label"></dt>
+                <dt data-i18n-static="emailpro_ACTION_update_account_step2_first_name_label"></dt>
                 <dd data-ng-if="selectedAccount.firstName"
                     data-ng-bind="selectedAccount.firstName"></dd>
                 <dd data-ng-if="!selectedAccount.firstName">-</dd>
 
-                <dt data-i18n-static="exchange_ACTION_update_account_step2_last_name_label"></dt>
+                <dt data-i18n-static="emailpro_ACTION_update_account_step2_last_name_label"></dt>
                 <dd data-ng-if="selectedAccount.lastName"
                     data-ng-bind="selectedAccount.lastName"></dd>
                 <dd data-ng-if="!selectedAccount.lastName">-</dd>
 
-                <dt data-i18n-static="exchange_ACTION_update_account_step2_display_name_label"></dt>
+                <dt data-i18n-static="emailpro_ACTION_update_account_step2_display_name_label"></dt>
                 <dd data-ng-if="selectedAccount.displayName"
                     data-ng-bind="selectedAccount.displayName"></dd>
                 <dd data-ng-if="!selectedAccount.displayName">-</dd>
 
-                <dt data-i18n-static="exchange_ACTION_update_account_step2_password_label"
+                <dt data-i18n-static="emailpro_ACTION_update_account_step2_password_label"
                     data-ng-if="selectedAccount.password"></dt>
                 <dd data-ng-if="selectedAccount.password">
                     <span data-ng-repeat="x in selectedAccount.password track by $index">*</span>
                 </dd>
 
-                <dt data-i18n-static="exchange_ACTION_update_account_step1_quota_label"
+                <dt data-i18n-static="emailpro_ACTION_update_account_step1_quota_label"
                     data-ng-if="!selectedAccount.is25g && exchange.offer == accountTypeProvider"></dt>
                 <dd data-ng-if="!selectedAccount.is25g && exchange.offer == accountTypeProvider">
                     <span data-ng-bind="selectedAccount.quota"></span> <span data-i18n-static="unit_size_GB"></span>

--- a/src/emailpro/disclaimer/add/emailpro-disclaimer-add.html
+++ b/src/emailpro/disclaimer/add/emailpro-disclaimer-add.html
@@ -2,7 +2,7 @@
     <div data-wizard
          data-wizard-on-cancel="resetAction"
          data-wizard-on-finish="saveDisclaimer"
-         data-wizard-title="i18n.exchange_ACTION_add_disclaimer_title">
+         data-wizard-title="i18n.emailpro_ACTION_add_disclaimer_title">
 
         <div data-wizard-step
              data-wizard-step-valid="data.completeDomain && data.content && data.content.length < 5000">
@@ -14,7 +14,7 @@
             <div data-ng-if="!loadingData">
                 <form class="form-horizontal">
                     <label class="oui-label" for="completeDomain"
-                           data-i18n-static="exchange_ACTION_disclaimer_associated_domains"></label>
+                           data-i18n-static="emailpro_ACTION_disclaimer_associated_domains"></label>
                     <div class="oui-select">
                         <select class="oui-select__input" required
                                 name="completeDomain" id="completeDomain"
@@ -27,18 +27,18 @@
                 <form class="form-inline my-3">
                     <div class="oui-field">
                         <label for="variableSelect" class="oui-field__label oui-label"
-                               data-i18n-static="exchange_ACTION_disclaimer_insert"></label>
+                               data-i18n-static="emailpro_ACTION_disclaimer_insert"></label>
                         <div class="oui-field__content">
                             <div class="oui-select">
                                 <select class="oui-select__input" id="variableSelect" name="variableSelect"
                                         data-ng-model="data.selectedAttribute"
-                                        data-ng-options="tr('exchange_ACTION_add_disclaimer_option_' +variable) for variable in availableAttributes">
+                                        data-ng-options="tr('emailpro_ACTION_add_disclaimer_option_' +variable) for variable in availableAttributes">
                                 </select>
                                 <span class="oui-icon oui-icon-chevron-down" aria-hidden="true"></span>
                             </div>
                             <button class="oui-button oui-button_secondary" type="button"
                                     data-ng-click="insertVariable()"
-                                    data-i18n-static="exchange_ACTION_disclaimer_insert"
+                                    data-i18n-static="emailpro_ACTION_disclaimer_insert"
                                     data-ng-enabled="data.selectedAttribute">
                             </button>
                         </div>
@@ -47,16 +47,16 @@
                 <textarea id="add-disclaimer-editor" data-ckeditor data-ng-model="data.content">{{data.content}}</textarea>
                 <oui-checkbox id="outsideOnly" name="outsideOnly"
                     data-model="data.outsideOnly"
-                    data-text="{{::i18n.exchange_ACTION_add_disclaimer_outside}}">
+                    data-text="{{::i18n.emailpro_ACTION_add_disclaimer_outside}}">
                 </oui-checkbox>
                 <div class="alert alert-warning" role="alert"
                      data-ng-show="data.content.length > 5000"
-                     data-i18n-static="exchange_ACTION_update_disclaimer_length_warning">
+                     data-i18n-static="emailpro_ACTION_update_disclaimer_length_warning">
                 </div>
             </div>
 
             <div data-wizard-step-help>
-                <h3 data-i18n-static="exchange_ACTION_add_disclaimer_helpwizard_title"></h3>
+                <h3 data-i18n-static="emailpro_ACTION_add_disclaimer_helpwizard_title"></h3>
                 <p data-ng-bind-html="tr('emailpro_ACTION_add_disclaimer_helpwizard_details1')"></p>
                 <p>
                     <span data-ng-bind-html="tr('emailpro_ACTION_add_disclaimer_helpwizard_details2')"></span>

--- a/src/emailpro/disclaimer/emailpro-disclaimer.controller.js
+++ b/src/emailpro/disclaimer/emailpro-disclaimer.controller.js
@@ -41,7 +41,7 @@ angular.module('Module.emailpro.controllers')
           }
         })
         .catch((data) => {
-          $scope.setMessage($scope.tr('exchange_tab_DISCLAIMER_error_message'), data.data);
+          $scope.setMessage($scope.tr('emailpro_tab_DISCLAIMER_error_message'), data.data);
         });
     };
 
@@ -58,7 +58,7 @@ angular.module('Module.emailpro.controllers')
             },
           };
         }).catch((data) => {
-          $scope.setMessage($scope.tr('exchange_tab_DISCLAIMER_error_message'), data.data);
+          $scope.setMessage($scope.tr('emailpro_tab_DISCLAIMER_error_message'), data.data);
         });
     };
 
@@ -134,7 +134,7 @@ angular.module('Module.emailpro.controllers')
           $scope.availableAttributes = data.availableAttributes;
         } else {
           $scope.resetAction();
-          $scope.setMessage($scope.tr('exchange_ACTION_add_disclaimer_no_domains'));
+          $scope.setMessage($scope.tr('emailpro_ACTION_add_disclaimer_no_domains'));
         }
         return $scope.data;
       });
@@ -158,11 +158,11 @@ angular.module('Module.emailpro.controllers')
         content: $scope.data.content,
       };
 
-      $scope.setMessage($scope.tr('exchange_dashboard_action_doing'), { status: 'success' });
+      $scope.setMessage($scope.tr('emailpro_dashboard_action_doing'), { status: 'success' });
       EmailPro.saveDisclaimer($stateParams.productId, model).then(() => {
-        $scope.setMessage($scope.tr('exchange_ACTION_add_disclaimer_success_message'), { status: 'success' });
+        $scope.setMessage($scope.tr('emailpro_ACTION_add_disclaimer_success_message'), { status: 'success' });
       }, (failure) => {
-        $scope.setMessage($scope.tr('exchange_ACTION_add_disclaimer_error_message'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_ACTION_add_disclaimer_error_message'), failure.data);
       });
       $scope.resetAction();
     };
@@ -214,11 +214,11 @@ angular.module('Module.emailpro.controllers')
         content: $scope.data.content,
       };
 
-      $scope.setMessage($scope.tr('exchange_dashboard_action_doing'));
+      $scope.setMessage($scope.tr('emailpro_dashboard_action_doing'));
       EmailPro.updateDisclaimer($stateParams.productId, model).then(() => {
-        $scope.setMessage($scope.tr('exchange_ACTION_update_disclaimer_success_message'), { status: 'success' });
+        $scope.setMessage($scope.tr('emailpro_ACTION_update_disclaimer_success_message'), { status: 'success' });
       }, (failure) => {
-        $scope.setMessage($scope.tr('exchange_ACTION_update_disclaimer_error_message'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_ACTION_update_disclaimer_error_message'), failure.data);
       });
       $scope.resetAction();
     };
@@ -228,12 +228,12 @@ angular.module('Module.emailpro.controllers')
   .controller('EmailProRemoveDisclaimerCtrl', ($scope, $stateParams, EmailPro) => {
     $scope.disclaimer = $scope.currentActionData;
     $scope.submit = function () {
-      $scope.setMessage($scope.tr('exchange_dashboard_action_doing'), { status: 'success' });
+      $scope.setMessage($scope.tr('emailpro_dashboard_action_doing'), { status: 'success' });
       EmailPro.deleteDisclaimer($stateParams.productId, $scope.disclaimer.domain.name)
         .then(() => {
-          $scope.setMessage($scope.tr('exchange_ACTION_delete_disclaimer_success'), { status: 'success' });
+          $scope.setMessage($scope.tr('emailpro_ACTION_delete_disclaimer_success'), { status: 'success' });
         }, (failure) => {
-          $scope.setMessage($scope.tr('exchange_ACTION_delete_disclaimer_failure'), failure.data);
+          $scope.setMessage($scope.tr('emailpro_ACTION_delete_disclaimer_failure'), failure.data);
         });
       $scope.resetAction();
     };

--- a/src/emailpro/disclaimer/emailpro-disclaimer.html
+++ b/src/emailpro/disclaimer/emailpro-disclaimer.html
@@ -1,43 +1,43 @@
 <div class="container-fluid px-0" data-ng-controller="EmailProDisclaimerCtrl">
     <div class="alert alert-warning" role="alert"
          data-ng-if="tasksList && tasksList.list.messages.length > 0">
-        <strong data-i18n-static="exchange_tab_TASKS_warning"></strong>
-        <span data-i18n-static="exchange_tab_TASKS_partial"></span>
+        <strong data-i18n-static="emailpro_tab_TASKS_warning"></strong>
+        <span data-i18n-static="emailpro_tab_TASKS_partial"></span>
     </div>
 
     <div class="alert alert-info" role="alert"
-         data-i18n-static="exchange_tab_DISCLAIMER_table_no_domain"
+         data-i18n-static="emailpro_tab_DISCLAIMER_table_no_domain"
          data-ng-if="addDomainMessageFlag">
     </div>
 
     <oui-datagrid data-rows-loader="loadPaginated($config)">
-        <oui-column data-title="tr('exchange_tab_DISCLAIMER_associated_domains')" data-property="domain.displayName"></oui-column>
-        <oui-column data-title="tr('exchange_tab_DISCLAIMER_disclaimer_content')" data-property="strippedContent">
+        <oui-column data-title="tr('emailpro_tab_DISCLAIMER_associated_domains')" data-property="domain.displayName"></oui-column>
+        <oui-column data-title="tr('emailpro_tab_DISCLAIMER_disclaimer_content')" data-property="strippedContent">
             <span data-ng-bind="$row.strippedContent | sliceContent:60"></span>
         </oui-column>
-        <oui-column data-title="tr('exchange_tab_DISCLAIMER_disclaimer_outside_only')">
-            <span data-i18n-static="exchange_tab_DISCLAIMER_disclaimer_outside_only_true"
+        <oui-column data-title="tr('emailpro_tab_DISCLAIMER_disclaimer_outside_only')">
+            <span data-i18n-static="emailpro_tab_DISCLAIMER_disclaimer_outside_only_true"
                   data-ng-if="$row.outsideOnly"
-                  data-uib-tooltip="{{i18n.exchange_tab_DISCLAIMER_disclaimer_outside_only_tooltip}}"
+                  data-uib-tooltip="{{i18n.emailpro_tab_DISCLAIMER_disclaimer_outside_only_tooltip}}"
                   data-tooltip-append-to-body="true"></span>
-            <span data-i18n-static="exchange_tab_DISCLAIMER_disclaimer_outside_only_false"
+            <span data-i18n-static="emailpro_tab_DISCLAIMER_disclaimer_outside_only_false"
                   data-ng-if="!$row.outsideOnly"></span>
         </oui-column>
-        <oui-column data-title="tr('exchange_tab_DISCLAIMER_state_header')">
+        <oui-column data-title="tr('emailpro_tab_DISCLAIMER_state_header')">
             <span class="fa fa-hourglass-half"
                   data-ng-if="$row.taskPendingId"
-                  data-uib-tooltip="{{tr('exchange_tab_DISCLAIMER_state_doing_tooltip')}}"
+                  data-uib-tooltip="{{tr('emailpro_tab_DISCLAIMER_state_doing_tooltip')}}"
                   data-tooltip-append-to-body="true"></span>
             <span class="label label-warning"
                   data-i18n-static="common_not_configurated"
                   data-ng-if="$row.emptySlotFlag"></span>
         </oui-column>
         <oui-action-menu data-align="end" data-compact>
-            <oui-action-menu-item data-text="{{i18n.exchange_tab_DISCLAIMER_menu_settings}}"
+            <oui-action-menu-item data-text="{{i18n.emailpro_tab_DISCLAIMER_menu_settings}}"
                                   data-on-click="updateDisclaimer($row)"
                                   data-ng-if="!$row.emptySlotFlag"
                                   data-disabled="$row.taskPendingId"></oui-action-menu-item>
-            <oui-action-menu-item data-text="{{i18n.exchange_tab_DISCLAIMER_menu_delete}}"
+            <oui-action-menu-item data-text="{{i18n.emailpro_tab_DISCLAIMER_menu_delete}}"
                                   data-on-click="deleteDisclaimer($row)"
                                   data-ng-if="!$row.emptySlotFlag"
                                   data-disabled="$row.taskPendingId"></oui-action-menu-item>

--- a/src/emailpro/disclaimer/remove/emailpro-disclaimer-remove.html
+++ b/src/emailpro/disclaimer/remove/emailpro-disclaimer-remove.html
@@ -2,16 +2,16 @@
     <div data-wizard
          data-wizard-on-cancel="resetAction"
          data-wizard-on-finish="submit"
-         data-wizard-title="i18n.exchange_ACTION_delete_disclaimer_title">
+         data-wizard-title="i18n.emailpro_ACTION_delete_disclaimer_title">
 
         <div data-wizard-step>
             <p data-i18n-static="emailpro_ACTION_delete_disclaimer_question"></p>
 
             <dl class="dl-horizontal mt-5">
-                <dt data-i18n-static="exchange_ACTION_disclaimer_associated_domains"></dt>
+                <dt data-i18n-static="emailpro_ACTION_disclaimer_associated_domains"></dt>
                 <dd data-ng-bind="disclaimer.domain.displayName"></dd>
 
-                <dt data-i18n-static="exchange_ACTION_add_disclaimer_content"></dt>
+                <dt data-i18n-static="emailpro_ACTION_add_disclaimer_content"></dt>
                 <dd data-ng-bind-html="disclaimer.content | sliceContent:250"></dd>
             </dl>
         </div>

--- a/src/emailpro/disclaimer/update/emailpro-disclaimer-update.html
+++ b/src/emailpro/disclaimer/update/emailpro-disclaimer-update.html
@@ -2,7 +2,7 @@
     <div data-wizard
          data-wizard-on-cancel="resetAction"
          data-wizard-on-finish="saveDisclaimer"
-         data-wizard-title="i18n.exchange_ACTION_update_disclaimer_title">
+         data-wizard-title="i18n.emailpro_ACTION_update_disclaimer_title">
 
         <div data-wizard-step
              data-wizard-step-valid="data.content && data.content.length < 5000">
@@ -12,22 +12,22 @@
             </div>
 
             <div data-ng-if="!loadingData">
-                <strong data-ng-bind-html="tr('exchange_ACTION_update_disclaimer_info', [data.domain.displayName])"></strong>
+                <strong data-ng-bind-html="tr('emailpro_ACTION_update_disclaimer_info', [data.domain.displayName])"></strong>
                 <form class="form-inline my-3">
                     <div class="oui-field">
                         <label for="variableSelect" class="oui-field__label oui-label"
-                               data-i18n-static="exchange_ACTION_disclaimer_insert"></label>
+                               data-i18n-static="emailpro_ACTION_disclaimer_insert"></label>
                         <div class="oui-field__content">
                             <div class="oui-select">
                                 <select class="oui-select__input" id="variableSelect" name="variableSelect"
                                         data-ng-model="data.selectedAttribute"
-                                        data-ng-options="tr('exchange_ACTION_add_disclaimer_option_' +variable) for variable in availableAttributes">
+                                        data-ng-options="tr('emailpro_ACTION_add_disclaimer_option_' +variable) for variable in availableAttributes">
                                 </select>
                                 <span class="oui-icon oui-icon-chevron-down" aria-hidden="true"></span>
                             </div>
                             <button class="oui-button oui-button_secondary" type="button"
                                     data-ng-click="insertAttribute()"
-                                    data-i18n-static="exchange_ACTION_disclaimer_insert"
+                                    data-i18n-static="emailpro_ACTION_disclaimer_insert"
                                     data-ng-enabled="data.selectedAttribute">
                             </button>
                         </div>
@@ -36,16 +36,16 @@
                 <textarea id="update-disclaimer-editor" data-ckeditor data-ng-model="data.content">{{data.content}}</textarea>
                 <oui-checkbox id="outsideOnly" name="outsideOnly"
                     data-model="data.outsideOnly"
-                    data-text="{{::i18n.exchange_ACTION_add_disclaimer_outside}}">
+                    data-text="{{::i18n.emailpro_ACTION_add_disclaimer_outside}}">
                 </oui-checkbox>
                 <div class="alert alert-warning" role="alert"
                      data-ng-if="data.content.length > 5000"
-                     data-i18n-static="exchange_ACTION_update_disclaimer_length_warning">
+                     data-i18n-static="emailpro_ACTION_update_disclaimer_length_warning">
                 </div>
             </div>
 
             <div data-wizard-step-help>
-                <h3 data-i18n-static="exchange_ACTION_add_disclaimer_helpwizard_title"></h3>
+                <h3 data-i18n-static="emailpro_ACTION_add_disclaimer_helpwizard_title"></h3>
                 <p data-ng-bind-html="tr('emailpro_ACTION_add_disclaimer_helpwizard_details1')"></p>
                 <p>
                     <span data-ng-bind-html="tr('emailpro_ACTION_add_disclaimer_helpwizard_details2')"></span>

--- a/src/emailpro/domain/add/emailpro-domain-add.html
+++ b/src/emailpro/domain/add/emailpro-domain-add.html
@@ -3,7 +3,7 @@
     <div data-wizard
          data-wizard-on-cancel="resetAction"
          data-wizard-on-finish="addDomain"
-         data-wizard-title="i18n.exchange_tab_domain_add_domain">
+         data-wizard-title="i18n.emailpro_tab_domain_add_domain">
 
         <div data-wizard-step
              data-wizard-step-on-load="loadDomainData"
@@ -28,12 +28,12 @@
                            class="oui-radio__input">
                     <label class="oui-radio__label-container" for="addOption1">
                         <span class="oui-radio__label"
-                              data-i18n-static="exchange_tab_domain_add_step1_select_domain_option"></span>
+                              data-i18n-static="emailpro_tab_domain_add_step1_select_domain_option"></span>
                     </label>
                 </div>
                 <div class="form-group" data-ng-if="model.domainType === ovhDomain">
                     <div class="input-group">
-                        <input type="text" class="form-control" placeholder="{{i18n.exchange_tab_domain_search}}"
+                        <input type="text" class="form-control" placeholder="{{i18n.emailpro_tab_domain_search}}"
                                data-ng-model="search.value"
                                data-ng-change="resetName()">
                         <div class="input-group-btn" data-ng-if="search.value">
@@ -60,7 +60,7 @@
                         </button>
                     </li>
                     <li data-ng-if="availableDomains.length === 0 && search.value"
-                        data-i18n-static="exchange_tab_domain_add_step1_domain_none">
+                        data-i18n-static="emailpro_tab_domain_add_step1_domain_none">
                     </li>
                 </ul>
                 <div class="oui-radio">
@@ -72,7 +72,7 @@
                     <label class="oui-radio__label-container" for="addOption2">
                         <span id="nonOvhDomain"
                               class="oui-radio__label"
-                              data-i18n-static="exchange_tab_domain_add_step1_user_owned_option"></span>
+                              data-i18n-static="emailpro_tab_domain_add_step1_user_owned_option"></span>
                     </label>
                 </div>
                 <div class="form-group"
@@ -80,7 +80,7 @@
                     data-ng-if="model.domainType === nonOvhDomain">
                     <input type="text"
                            class="form-control"
-                           placeholder="{{i18n.exchange_tab_domain_domain}}"
+                           placeholder="{{i18n.emailpro_tab_domain_domain}}"
                            aria-labelledby="nonOvhDomain"
                            data-ng-model="model.displayName"
                            data-ng-change="changeName()">
@@ -88,15 +88,15 @@
                           data-ng-if="!isNonOvhDomainValid()"
                           data-i18n-static="emailpro_ACTION_add_domain_invalid_domain"></span>
                     <div class="alert alert-warning mt-4" role="alert"
-                         data-i18n-static="exchange_tab_domain_add_step1_user_owned_info">
+                         data-i18n-static="emailpro_tab_domain_add_step1_user_owned_info">
                     </div>
                 </div>
             </form>
 
             <div data-wizard-step-help>
-                <h3 data-i18n-static="exchange_tab_TASKS_ADD_DOMAIN"></h3>
-                <h4 data-i18n-static="exchange_tab_domain_step1_helpwizard_subdomain_title"></h4>
-                <p data-ng-bind-html="tr('exchange_tab_domain_step1_helpwizard_subdomain')"></p>
+                <h3 data-i18n-static="emailpro_tab_TASKS_ADD_DOMAIN"></h3>
+                <h4 data-i18n-static="emailpro_tab_domain_step1_helpwizard_subdomain_title"></h4>
+                <p data-ng-bind-html="tr('emailpro_tab_domain_step1_helpwizard_subdomain')"></p>
             </div>
         </div>
 
@@ -104,7 +104,7 @@
              data-wizard-step-valid="model.type === 'AUTHORITATIVE' || (model.mxRelay && model.type === 'NON_AUTHORITATIVE')">
 
             <form name="emailProAddDomainStep2Form">
-                <p data-i18n-static="exchange_tab_domain_add_step2bis_intro"></p>
+                <p data-i18n-static="emailpro_tab_domain_add_step2bis_intro"></p>
                 <div class="oui-radio">
                     <input type="radio"
                            name="domainType" id="domainType-A"
@@ -132,7 +132,7 @@
                 </div>
                 <div class="form-group">
                     <label class="sr-only" for="targetMailServer"
-                           data-i18n-static="exchange_tab_domain_target_mail_server_label"></label>
+                           data-i18n-static="emailpro_tab_domain_target_mail_server_label"></label>
                     <input type="text"
                            name="targetMailServer"
                            class="form-control"
@@ -151,33 +151,33 @@
              data-wizard-step-valid="model.type">
 
             <p data-ng-if="model.type === 'AUTHORITATIVE'"
-               data-ng-bind-html="tr('exchange_tab_domain_add_step2_auth_intro', model.displayName)"></p>
+               data-ng-bind-html="tr('emailpro_tab_domain_add_step2_auth_intro', model.displayName)"></p>
             <p data-ng-if="model.type === 'NON_AUTHORITATIVE'"
-               data-ng-bind-html="tr('exchange_tab_domain_add_step2_non_auth_intro', model.displayName)"></p>
+               data-ng-bind-html="tr('emailpro_tab_domain_add_step2_non_auth_intro', model.displayName)"></p>
 
             <form name="emailProAddDomainStep3Form">
                 <div data-ng-if="model.domainType !== nonOvhDomain">
                     <oui-checkbox id="srvParam" name="srvParam"
                         data-model="model.srvParam"
-                        data-text="{{::i18n.exchange_tab_domain_add_step2_srv_checkbox}}">
+                        data-text="{{::i18n.emailpro_tab_domain_add_step2_srv_checkbox}}">
                     </oui-checkbox>
                     <div class="alert alert-info" role="alert"
                          data-ng-if="model.srvParam"
-                         data-i18n-static="exchange_tab_domain_add_step2_srv_tooltip">
+                         data-i18n-static="emailpro_tab_domain_add_step2_srv_tooltip">
                     </div>
                     <oui-checkbox id="mxParam" name="mxParam"
                         data-model="model.mxParam"
-                        data-text="{{::i18n.exchange_tab_domain_add_step2_mx_checkbox}}">
+                        data-text="{{::i18n.emailpro_tab_domain_add_step2_mx_checkbox}}">
                     </oui-checkbox>
                     <div class="alert alert-warning" role="alert"
                           data-ng-if="model.mxParam"
-                          data-i18n-static="exchange_tab_domain_add_step2_mx_tooltip">
+                          data-i18n-static="emailpro_tab_domain_add_step2_mx_tooltip">
                     </div>
                 </div>
                 <div class="alert alert-warning mt-3" role="alert"
                      data-ng-if="model.domainType === nonOvhDomain">
-                    <span data-i18n-static="exchange_tab_domain_noovh_mx_info"></span>
-                    <span data-i18n-static="exchange_tab_domain_add_step2_mx_tooltip"></span>
+                    <span data-i18n-static="emailpro_tab_domain_noovh_mx_info"></span>
+                    <span data-i18n-static="emailpro_tab_domain_add_step2_mx_tooltip"></span>
                 </div>
                 <div class="form-group" data-ng-if="setOrganization2010">
                     <div class="checkbox">
@@ -185,14 +185,14 @@
                             <input type="checkbox"
                                    name="mainDomain"
                                    data-ng-model="model.main">
-                            <span data-i18n-static="exchange_tab_domain_add_step1_main_domain"
-                                  data-uib-tooltip="{{i18n.exchange_tab_domain_add_step1_main_domain_tooltip}}"></span>
+                            <span data-i18n-static="emailpro_tab_domain_add_step1_main_domain"
+                                  data-uib-tooltip="{{i18n.emailpro_tab_domain_add_step1_main_domain_tooltip}}"></span>
                         </label>
                     </div>
                     <div class="form-group" data-ng-if="!model.main">
                         <label class="required"
                                for="mainDomainAttached"
-                               data-i18n-static="exchange_tab_domain_add_step1_attach_organization_intro">
+                               data-i18n-static="emailpro_tab_domain_add_step1_attach_organization_intro">
                         </label>
                         <select class="form-control"
                                 id="mainDomainAttached"
@@ -202,7 +202,7 @@
                         </select>
                     </div>
                     <p data-ng-if="model.main"
-                       data-ng-bind="tr('exchange_tab_domain_add_step1_new_organization_intro', [model.displayName])"></p>
+                       data-ng-bind="tr('emailpro_tab_domain_add_step1_new_organization_intro', [model.displayName])"></p>
                 </div>
             </form>
         </div>
@@ -210,32 +210,32 @@
         <div data-wizard-step>
             <p data-i18n-static="emailpro_tab_domain_add_step3_confirmation"></p>
             <dl class="dl-horizontal mt-3">
-                <dt data-i18n-static="exchange_tab_domain_domain"></dt>
+                <dt data-i18n-static="emailpro_tab_domain_domain"></dt>
                 <dd>
                     <span data-ng-bind="model.displayName"></span>
                     <span data-ng-if="model.isUTF8Domain"> (<span data-ng-bind="model.name"></span>)</span>
                 </dd>
 
-                <dt data-i18n-static="exchange_tab_domain_type"></dt>
-                <dd data-ng-bind="tr('exchange_tab_domain_' + model.type)"></dd>
+                <dt data-i18n-static="emailpro_tab_domain_type"></dt>
+                <dd data-ng-bind="tr('emailpro_tab_domain_' + model.type)"></dd>
 
                 <dt data-ng-if="model.domainType !== nonOvhDomain"
-                    data-i18n-static="exchange_tab_domain_add_step3_mx_confirmation"></dt>
+                    data-i18n-static="emailpro_tab_domain_add_step3_mx_confirmation"></dt>
                 <dd data-ng-if="model.domainType !== nonOvhDomain"
-                    data-ng-bind="tr('exchange_tab_domain_add_step3_configuration_' + model.mxParam)"></dd>
+                    data-ng-bind="tr('emailpro_tab_domain_add_step3_configuration_' + model.mxParam)"></dd>
 
                 <dt data-ng-if="model.domainType !== nonOvhDomain"
-                    data-i18n-static="exchange_tab_domain_add_step3_srv_confirmation"></dt>
+                    data-i18n-static="emailpro_tab_domain_add_step3_srv_confirmation"></dt>
                 <dd data-ng-if="model.domainType !== nonOvhDomain"
-                    data-ng-bind="tr('exchange_tab_domain_add_step3_configuration_' + model.srvParam)"></dd>
+                    data-ng-bind="tr('emailpro_tab_domain_add_step3_configuration_' + model.srvParam)"></dd>
 
                 <dt data-ng-if="setOrganization2010"
-                    data-i18n-static="exchange_tab_domain_add_step2_main_domain"></dt>
+                    data-i18n-static="emailpro_tab_domain_add_step2_main_domain"></dt>
                 <dd data-ng-if="setOrganization2010"
-                    data-ng-bind="tr('exchange_tab_domain_add_step2_main_domain_' + model.main)"></dd>
+                    data-ng-bind="tr('emailpro_tab_domain_add_step2_main_domain_' + model.main)"></dd>
 
                 <dt data-ng-if="setOrganization2010"
-                    data-i18n-static="exchange_tab_domain_add_step2_organization"></dt>
+                    data-i18n-static="emailpro_tab_domain_add_step2_organization"></dt>
                 <dd data-ng-if="setOrganization2010 && model.main && model.organization2010"
                     data-ng-bind="model.organization2010"></dd>
                 <dd data-ng-if="setOrganization2010 && model.main && !model.organization2010"

--- a/src/emailpro/domain/emailpro-domain.controller.js
+++ b/src/emailpro/domain/emailpro-domain.controller.js
@@ -54,17 +54,17 @@ angular.module('Module.emailpro.controllers').controller('EmailProTabDomainsCtrl
 
   function setMxTooltip(domain) {
     if (domain.mxValid) {
-      _.set(domain, 'mxTooltip', $scope.tr('exchange_tab_domain_diagnostic_mx_toolbox_ok'));
+      _.set(domain, 'mxTooltip', $scope.tr('emailpro_tab_domain_diagnostic_mx_toolbox_ok'));
     } else {
-      _.set(domain, 'mxTooltip', $scope.tr('exchange_tab_domain_diagnostic_mx_toolbox', [$scope.exchange.hostname]));
+      _.set(domain, 'mxTooltip', $scope.tr('emailpro_tab_domain_diagnostic_mx_toolbox', [$scope.exchange.hostname]));
     }
   }
 
   function setSrvTooltip(domain) {
     if (domain.srvValid) {
-      _.set(domain, 'srvTooltip', $scope.tr('exchange_tab_domain_diagnostic_srv_toolbox_ok'));
+      _.set(domain, 'srvTooltip', $scope.tr('emailpro_tab_domain_diagnostic_srv_toolbox_ok'));
     } else {
-      _.set(domain, 'srvTooltip', $scope.tr('exchange_tab_domain_diagnostic_srv_toolbox', [$scope.exchange.hostname]));
+      _.set(domain, 'srvTooltip', $scope.tr('emailpro_tab_domain_diagnostic_srv_toolbox', [$scope.exchange.hostname]));
     }
   }
 

--- a/src/emailpro/domain/emailpro-domain.html
+++ b/src/emailpro/domain/emailpro-domain.html
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="col-md-9">
             <div class="alert alert-warning" role="alert"
-                 data-i18n-static="exchange_tab_domain_partial"
+                 data-i18n-static="emailpro_tab_domain_partial"
                  data-ng-if="containPartial()"></div>
             <div class="text-right mb-3">
                 <form class="form-inline" name="searchDomainForm">
@@ -10,7 +10,7 @@
                         <label class="sr-only" for="searchDomain"
                                data-i18n-static="common_search"></label>
                         <div class="input-group">
-                            <input type="text" class="form-control" id="searchDomain" name="searchDomain" placeholder="{{::i18n.exchange_tab_domain_search}}"
+                            <input type="text" class="form-control" id="searchDomain" name="searchDomain" placeholder="{{::i18n.emailpro_tab_domain_search}}"
                                    data-ng-disabled="loading || paginated.domains.length === 0"
                                    data-ng-model="search.value"
                                    data-ng-model-options="{debounce: 800}">
@@ -34,11 +34,11 @@
                 <table class="table table-hover">
                     <thead>
                         <tr>
-                            <th scope="col" data-i18n-static="exchange_tab_domain_domain"></th>
-                            <th scope="col" data-i18n-static="exchange_tab_domain_type"></th>
-                            <th class="text-center" scope="col" data-i18n-static="exchange_tab_domain_accounts_count"></th>
-                            <th class="text-center" scope="col" data-i18n-static="exchange_tab_domain_diagnostic"></th>
-                            <th class="text-center" scope="col" data-i18n-static="exchange_tab_domain_status"></th>
+                            <th scope="col" data-i18n-static="emailpro_tab_domain_domain"></th>
+                            <th scope="col" data-i18n-static="emailpro_tab_domain_type"></th>
+                            <th class="text-center" scope="col" data-i18n-static="emailpro_tab_domain_accounts_count"></th>
+                            <th class="text-center" scope="col" data-i18n-static="emailpro_tab_domain_diagnostic"></th>
+                            <th class="text-center" scope="col" data-i18n-static="emailpro_tab_domain_status"></th>
                             <th class="min-width" scope="col"></th>
                         </tr>
                     </thead>
@@ -57,11 +57,11 @@
                                     <button class="btn btn-link p-0"
                                             type="button"
                                             style="font-size:inherit"
-                                            data-i18n-static="exchange_tab_domain_no_domains_2"
+                                            data-i18n-static="emailpro_tab_domain_no_domains_2"
                                             data-ng-click="setAction('emailpro/domain/add/emailpro-domain-add')"></button>
-                                    <span data-i18n-static="exchange_tab_domain_no_domains_3"></span>
+                                    <span data-i18n-static="emailpro_tab_domain_no_domains_3"></span>
                                 </div>
-                                <span data-i18n-static="exchange_tab_domain_table_empty_search" data-ng-if="search.value"></span>
+                                <span data-i18n-static="emailpro_tab_domain_table_empty_search" data-ng-if="search.value"></span>
                             </td>
                         </tr>
                     </tbody>
@@ -79,19 +79,19 @@
 
                             <td data-ng-if="!domain.partial && domain.domainValidated">
                                 <span data-ng-if="domain.taskInProgress && !domain.partial && domain.state === stateOk && domain.type === domainTypeAuthoritative"
-                                      data-ng-bind="tr('exchange_tab_domain_modify_in_progress', tr('exchange_tab_domain_inverse_NON_AUTHORITATIVE'))"></span>
+                                      data-ng-bind="tr('emailpro_tab_domain_modify_in_progress', tr('emailpro_tab_domain_inverse_NON_AUTHORITATIVE'))"></span>
                                 <span data-ng-if="domain.taskInProgress && !domain.partial && domain.state === stateOk && domain.type === domainTypeNonAuthoritative"
-                                      data-ng-bind="tr('exchange_tab_domain_modify_in_progress', tr('exchange_tab_domain_inverse_AUTHORITATIVE'))"></span>
+                                      data-ng-bind="tr('emailpro_tab_domain_modify_in_progress', tr('emailpro_tab_domain_inverse_AUTHORITATIVE'))"></span>
                                 <span data-ng-if="!domain.partial && (domain.state === 'DELETING' || domain.state === 'CREATING')"
-                                      data-ng-bind="tr('exchange_tab_domain_' + domain.type)"></span>
+                                      data-ng-bind="tr('emailpro_tab_domain_' + domain.type)"></span>
                                 <span data-ng-if="!domain.taskInProgress && !domain.partial && domain.state === stateOk"
-                                      data-ng-bind="tr('exchange_tab_domain_' + domain.type)"></span>
+                                      data-ng-bind="tr('emailpro_tab_domain_' + domain.type)"></span>
                             </td>
                             <td colspan="2"
                                 data-ng-if="!domain.partial && !domain.domainValidated">
-                                <span data-i18n-static="exchange_tab_domain_validation_doing"></span>
+                                <span data-i18n-static="emailpro_tab_domain_validation_doing"></span>
                                 <span class="d-block"
-                                      data-i18n-static="exchange_tab_domain_validation_cname"
+                                      data-i18n-static="emailpro_tab_domain_validation_cname"
                                       data-ng-if="domain.cname"></span>
                             </td>
                             <td class="text-center"
@@ -101,39 +101,39 @@
                                 data-ng-if="!domain.partial">
                                 <div data-ng-if="domain.domainValidated">
                                     <button class="btn btn-danger btn-xs" type="button"
-                                            data-i18n-static="exchange_tab_domain_diagnostic_mx"
+                                            data-i18n-static="emailpro_tab_domain_diagnostic_mx"
                                             data-ng-click="setAction('emailpro/domain/mx-autoconfig/emailpro-domain-mx-autoconfig', domain)"
                                             data-ng-if="domain.mxValid === false">
                                     </button>
                                     <button class="btn btn-success btn-xs" type="button"
-                                            data-i18n-static="exchange_tab_domain_diagnostic_mx"
+                                            data-i18n-static="emailpro_tab_domain_diagnostic_mx"
                                             data-ng-if="domain.mxValid"
                                             data-simplepopover="{{domain.mxTooltip}}"
-                                            data-simplepopover-title="{{tr('exchange_tab_domain_diagnostic_mx_title')}}"
+                                            data-simplepopover-title="{{tr('emailpro_tab_domain_diagnostic_mx_title')}}"
                                             data-simplepopover-placement="top"
                                             data-simplepopover-single="true">
                                     </button>
                                     <button class="btn btn-danger btn-xs" type="button"
-                                            data-i18n-static="exchange_tab_domain_diagnostic_srv"
+                                            data-i18n-static="emailpro_tab_domain_diagnostic_srv"
                                             data-ng-click="setAction('emailpro/domain/srv-autoconfig/emailpro-domain-srv-autoconfig', domain)"
                                             data-ng-if="domain.srvValid === false">
                                     </button>
                                     <button class="btn btn-success btn-xs" type="button"
-                                            data-i18n-static="exchange_tab_domain_diagnostic_srv"
+                                            data-i18n-static="emailpro_tab_domain_diagnostic_srv"
                                             data-ng-if="domain.srvValid"
                                             data-simplepopover="{{domain.srvTooltip}}"
-                                            data-simplepopover-title="{{tr('exchange_tab_domain_diagnostic_srv_title')}}"
+                                            data-simplepopover-title="{{tr('emailpro_tab_domain_diagnostic_srv_title')}}"
                                             data-simplepopover-placement="top"
                                             data-simplepopover-single="true">
                                     </button>
                                 </div>
                                 <button class="btn btn-danger btn-xs" type="button"
-                                        data-i18n-static="exchange_tab_domain_diagnostic_cname"
+                                        data-i18n-static="emailpro_tab_domain_diagnostic_cname"
                                         data-ng-if="!domain.domainValidated && domain.cname"
-                                        data-simplepopover="{{tr('exchange_tab_domain_validation_cname_details', [domain.cname, domain.name, cnameRedirection])}}"
+                                        data-simplepopover="{{tr('emailpro_tab_domain_validation_cname_details', [domain.cname, domain.name, cnameRedirection])}}"
                                         data-simplepopover-placement="top"
                                         data-simplepopover-single="true"
-                                        data-simplepopover-title="{{tr('exchange_tab_domain_validation_cname_title')}}">
+                                        data-simplepopover-title="{{tr('emailpro_tab_domain_validation_cname_title')}}">
                                 </button>
                             </td>
                             <td class="text-center"
@@ -143,19 +143,19 @@
                                           data-i18n-static="global_OK"
                                           data-ng-if="!domain.taskInProgress"></span>
                                     <span class="label label-info"
-                                          data-i18n-static="exchange_tab_domain_task_in_progress"
+                                          data-i18n-static="emailpro_tab_domain_task_in_progress"
                                           data-ng-if="domain.taskInProgress"></span>
                                 </div>
                                 <div data-ng-if="domain.state === stateCreating || domain.state === stateDeleting">
                                     <span class="label label-info"
                                           data-ng-if="!domain.domainValidated && domain.cname"
-                                          data-i18n-static="exchange_tab_domain_validation"></span>
+                                          data-i18n-static="emailpro_tab_domain_validation"></span>
                                     <span class="label label-info"
                                           data-ng-if="domain.state === stateCreating && domain.cname == null"
-                                          data-i18n-static="exchange_tab_ACCOUNTS_state_CREATING"></span>
+                                          data-i18n-static="emailpro_tab_ACCOUNTS_state_CREATING"></span>
                                     <span class="label label-danger"
                                           data-ng-if="domain.state === stateDeleting"
-                                          data-i18n-static="exchange_tab_ACCOUNTS_state_DELETING"></span>
+                                          data-i18n-static="emailpro_tab_ACCOUNTS_state_DELETING"></span>
                                 </div>
                             </td>
                             <td class="text-center text-nowrap"
@@ -193,7 +193,7 @@
 
         <div class="col-md-3 mt-5 mt-lg-0">
             <button class="btn btn-block btn-default" type="button"
-                    data-i18n-static="exchange_tab_domain_add_domain"
+                    data-i18n-static="emailpro_tab_domain_add_domain"
                     data-ng-click="setAction('emailpro/domain/add/emailpro-domain-add', {})">
             </button>
         </div>

--- a/src/emailpro/domain/mx-autoconfig/emailpro-domain-mx-autoconfig.controller.js
+++ b/src/emailpro/domain/mx-autoconfig/emailpro-domain-mx-autoconfig.controller.js
@@ -16,7 +16,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProDomainMxAutoco
       };
     }, (failure) => {
       $scope.resetAction();
-      $scope.setMessage($scope.tr('exchange_tab_domain_diagnostic_add_field_failure'), failure);
+      $scope.setMessage($scope.tr('emailpro_tab_domain_diagnostic_add_field_failure'), failure);
     });
   };
 
@@ -38,12 +38,12 @@ angular.module('Module.emailpro.controllers').controller('EmailProDomainMxAutoco
 
     EmailProDomains.addZoneDnsField($stateParams.productId, prepareModel()).then((success) => {
       if (success.state === 'OK') {
-        $scope.setMessage($scope.tr('exchange_tab_domain_diagnostic_add_field_success'), { status: 'done' });
+        $scope.setMessage($scope.tr('emailpro_tab_domain_diagnostic_add_field_success'), { status: 'done' });
       } else {
-        $scope.setMessage($scope.tr('exchange_tab_domain_diagnostic_add_field_failure'), { status: 'error' });
+        $scope.setMessage($scope.tr('emailpro_tab_domain_diagnostic_add_field_failure'), { status: 'error' });
       }
     }, (failure) => {
-      $scope.setMessage($scope.tr('exchange_tab_domain_diagnostic_add_field_failure'), failure);
+      $scope.setMessage($scope.tr('emailpro_tab_domain_diagnostic_add_field_failure'), failure);
     });
   };
 });

--- a/src/emailpro/domain/mx-autoconfig/emailpro-domain-mx-autoconfig.html
+++ b/src/emailpro/domain/mx-autoconfig/emailpro-domain-mx-autoconfig.html
@@ -2,7 +2,7 @@
     <div data-wizard
          data-wizard-on-cancel="resetAction"
          data-wizard-on-finish="configMX"
-         data-wizard-title="i18n.exchange_tab_domain_diagnostic_mx_title">
+         data-wizard-title="i18n.emailpro_tab_domain_diagnostic_mx_title">
 
         <div data-wizard-step
              data-wizard-step-valid="domainDiag.isOvhDomain"
@@ -13,28 +13,28 @@
             </div>
 
             <p data-ng-if="domainDiag.isOvhDomain"
-               data-ng-bind="tr('exchange_tab_domain_diagnostic_mx_intro_ovh', domain.displayName)"></p>
+               data-ng-bind="tr('emailpro_tab_domain_diagnostic_mx_intro_ovh', domain.displayName)"></p>
             <p data-ng-if="!domainDiag.isOvhDomain"
                data-ng-bind="tr('emailpro_tab_domain_diagnostic_mx_no_ovh')"></p>
 
             <dl class="dl-horizontal" data-ng-if="domainDiag">
-                <dt data-i18n-static="exchange_tab_domain_diagnostic_mx_label_champs"></dt>
-                <dd data-ng-bind-html="tr('exchange_tab_domain_diagnostic_mx_antispam_config', [domainDiag.mx.spam[0].priority, domainDiag.mx.spam[0].target, domainDiag.mx.spam[1].priority, domainDiag.mx.spam[1].target, domainDiag.mx.spam[2].priority, domainDiag.mx.spam[2].target, domainDiag.mx.spam[3].priority, domainDiag.mx.spam[3].target])"></dd>
+                <dt data-i18n-static="emailpro_tab_domain_diagnostic_mx_label_champs"></dt>
+                <dd data-ng-bind-html="tr('emailpro_tab_domain_diagnostic_mx_antispam_config', [domainDiag.mx.spam[0].priority, domainDiag.mx.spam[0].target, domainDiag.mx.spam[1].priority, domainDiag.mx.spam[1].target, domainDiag.mx.spam[2].priority, domainDiag.mx.spam[2].target, domainDiag.mx.spam[3].priority, domainDiag.mx.spam[3].target])"></dd>
             </dl>
         </div>
 
         <div data-wizard-step>
-            <p data-i18n-static="exchange_tab_domain_diagnostic_mx_recap"></p>
+            <p data-i18n-static="emailpro_tab_domain_diagnostic_mx_recap"></p>
 
             <dl class="dl-horizontal">
-                <dt data-i18n-static="exchange_tab_domain_domain"></dt>
+                <dt data-i18n-static="emailpro_tab_domain_domain"></dt>
                 <dd data-ng-bind="domain.displayName"></dd>
 
-                <dt data-ng-if="!model.antiSpam" data-i18n-static="exchange_tab_domain_diagnostic_mx_label_champs"></dt>
+                <dt data-ng-if="!model.antiSpam" data-i18n-static="emailpro_tab_domain_diagnostic_mx_label_champs"></dt>
                 <dd data-ng-if="!model.antiSpam" data-ng-bind-html="tr('emailpro_tab_domain_diagnostic_mx_no_antispam_config', [domainDiag.mx.noSpam[0].priority, domainDiag.mx.noSpam[0].target])"></dd>
 
-                <dt data-ng-if="model.antiSpam" data-i18n-static="exchange_tab_domain_diagnostic_mx_label_champs"></dt>
-                <dd data-ng-if="model.antiSpam" data-ng-bind-html="tr('exchange_tab_domain_diagnostic_mx_antispam_config', [domainDiag.mx.spam[0].priority, domainDiag.mx.spam[0].target, domainDiag.mx.spam[1].priority, domainDiag.mx.spam[1].target, domainDiag.mx.spam[2].priority, domainDiag.mx.spam[2].target, domainDiag.mx.spam[3].priority, domainDiag.mx.spam[3].target])"></dd>
+                <dt data-ng-if="model.antiSpam" data-i18n-static="emailpro_tab_domain_diagnostic_mx_label_champs"></dt>
+                <dd data-ng-if="model.antiSpam" data-ng-bind-html="tr('emailpro_tab_domain_diagnostic_mx_antispam_config', [domainDiag.mx.spam[0].priority, domainDiag.mx.spam[0].target, domainDiag.mx.spam[1].priority, domainDiag.mx.spam[1].target, domainDiag.mx.spam[2].priority, domainDiag.mx.spam[2].target, domainDiag.mx.spam[3].priority, domainDiag.mx.spam[3].target])"></dd>
             </dl>
 
         </div>

--- a/src/emailpro/domain/remove/emailpro-domain-remove.html
+++ b/src/emailpro/domain/remove/emailpro-domain-remove.html
@@ -2,15 +2,15 @@
     <div data-wizard
          data-wizard-on-cancel="resetAction"
          data-wizard-on-finish="submit"
-         data-wizard-title="i18n.exchange_tab_domain_remove_domain">
+         data-wizard-title="i18n.emailpro_tab_domain_remove_domain">
 
         <div data-wizard-step>
             <p data-i18n-static="emailpro_tab_domain_remove_title"></p>
             <dl class="dl-horizontal mt-3">
-                <dt data-i18n-static="exchange_tab_domain_domain"></dt>
+                <dt data-i18n-static="emailpro_tab_domain_domain"></dt>
                 <dd data-ng-bind="domain.displayName"></dd>
-                <dt data-i18n-static="exchange_tab_domain_type"></dt>
-                <dd data-ng-bind="tr('exchange_tab_domain_' + domain.type)"></dd>
+                <dt data-i18n-static="emailpro_tab_domain_type"></dt>
+                <dd data-ng-bind="tr('emailpro_tab_domain_' + domain.type)"></dd>
             </dl>
         </div>
     </div>

--- a/src/emailpro/domain/srv-autoconfig/emailpro-domain-srv-autoconfig.controller.js
+++ b/src/emailpro/domain/srv-autoconfig/emailpro-domain-srv-autoconfig.controller.js
@@ -27,7 +27,7 @@ angular
           (data) => { this.domainDiag = data; },
           (failure) => {
             this.services.$scope.resetAction();
-            this.services.$scope.setMessage(this.services.$scope.tr('exchange_tab_domain_diagnostic_add_field_failure'), failure);
+            this.services.$scope.setMessage(this.services.$scope.tr('emailpro_tab_domain_diagnostic_add_field_failure'), failure);
           },
         )
         .finally(() => {
@@ -50,10 +50,10 @@ angular
         .addZoneDnsField(this.services.$stateParams.productId, this.prepareModel())
         .then((success) => {
           if (success.state === 'OK') {
-            this.services.$scope.setMessage(this.services.$scope.tr('exchange_tab_domain_diagnostic_add_field_success'), { status: 'success' });
+            this.services.$scope.setMessage(this.services.$scope.tr('emailpro_tab_domain_diagnostic_add_field_success'), { status: 'success' });
           } else {
-            this.services.$scope.setMessage(this.services.$scope.tr('exchange_tab_domain_diagnostic_add_field_failure'), { status: 'error' });
+            this.services.$scope.setMessage(this.services.$scope.tr('emailpro_tab_domain_diagnostic_add_field_failure'), { status: 'error' });
           }
-        }, failure => this.services.$scope.setMessage(this.services.$scope.tr('exchange_tab_domain_diagnostic_add_field_failure'), failure));
+        }, failure => this.services.$scope.setMessage(this.services.$scope.tr('emailpro_tab_domain_diagnostic_add_field_failure'), failure));
     }
   });

--- a/src/emailpro/domain/srv-autoconfig/emailpro-domain-srv-autoconfig.html
+++ b/src/emailpro/domain/srv-autoconfig/emailpro-domain-srv-autoconfig.html
@@ -2,7 +2,7 @@
     <div data-wizard
          data-wizard-on-cancel="resetAction"
          data-wizard-on-finish="configSRV"
-         data-wizard-title="i18n.exchange_tab_domain_diagnostic_srv_title">
+         data-wizard-title="i18n.emailpro_tab_domain_diagnostic_srv_title">
 
         <div data-wizard-step
              data-wizard-step-valid="getIsOVHDomain">
@@ -13,25 +13,25 @@
 
             <div data-ng-if="!ctrl.loading.step1">
                 <p data-ng-if="ctrl.domainDiag.isOvhDomain"
-                   data-ng-bind="tr('exchange_tab_domain_diagnostic_srv_intro_ovh', ctrl.domain.displayName)"></p>
+                   data-ng-bind="tr('emailpro_tab_domain_diagnostic_srv_intro_ovh', ctrl.domain.displayName)"></p>
                 <p data-ng-if="!ctrl.domainDiag.isOvhDomain"
-                   data-ng-bind="tr('exchange_tab_domain_diagnostic_srv_no_ovh')"></p>
+                   data-ng-bind="tr('emailpro_tab_domain_diagnostic_srv_no_ovh')"></p>
                 <dl class="dl-horizontal">
-                    <dt data-i18n-static="exchange_tab_domain_diagnostic_srv_label_champ"></dt>
-                    <dd data-ng-bind-html="tr('exchange_tab_domain_diagnostic_srv_config', [ctrl.domainDiag.srv.subDomain, ctrl.domainDiag.srv.priority, ctrl.domainDiag.srv.weight, ctrl.domainDiag.srv.port, ctrl.domainDiag.srv.target])"></dd>
+                    <dt data-i18n-static="emailpro_tab_domain_diagnostic_srv_label_champ"></dt>
+                    <dd data-ng-bind-html="tr('emailpro_tab_domain_diagnostic_srv_config', [ctrl.domainDiag.srv.subDomain, ctrl.domainDiag.srv.priority, ctrl.domainDiag.srv.weight, ctrl.domainDiag.srv.port, ctrl.domainDiag.srv.target])"></dd>
                 </dl>
             </div>
         </div>
 
         <div data-wizard-step>
-            <p data-ng-bind-html="tr('exchange_tab_domain_diagnostic_srv_recap', ctrl.domainDiag.srv.subDomain)"></p>
+            <p data-ng-bind-html="tr('emailpro_tab_domain_diagnostic_srv_recap', ctrl.domainDiag.srv.subDomain)"></p>
 
             <dl class="dl-horizontal">
-                <dt data-i18n-static="exchange_tab_domain_domain"></dt>
+                <dt data-i18n-static="emailpro_tab_domain_domain"></dt>
                 <dd data-ng-bind="ctrl.domain.displayName"></dd>
 
-                <dt data-i18n-static="exchange_tab_domain_diagnostic_srv_label_champ"></dt>
-                <dd data-ng-bind-html="tr('exchange_tab_domain_diagnostic_srv_config', [ctrl.domainDiag.srv.subDomain, ctrl.domainDiag.srv.priority, ctrl.domainDiag.srv.weight, ctrl.domainDiag.srv.port, ctrl.domainDiag.srv.target])"></dd>
+                <dt data-i18n-static="emailpro_tab_domain_diagnostic_srv_label_champ"></dt>
+                <dd data-ng-bind-html="tr('emailpro_tab_domain_diagnostic_srv_config', [ctrl.domainDiag.srv.subDomain, ctrl.domainDiag.srv.priority, ctrl.domainDiag.srv.weight, ctrl.domainDiag.srv.port, ctrl.domainDiag.srv.target])"></dd>
             </dl>
         </div>
     </div>

--- a/src/emailpro/domain/update/emailpro-domain-update.controller.js
+++ b/src/emailpro/domain/update/emailpro-domain-update.controller.js
@@ -104,12 +104,12 @@ angular.module('Module.emailpro.controllers')
       EmailProDomains
         .updateDomain($stateParams.organization, $stateParams.productId, $scope.selectedDomain)
         .then(() => {
-          $scope.setMessage($scope.tr('exchange_tab_domain_modify_success'), 'true');
+          $scope.setMessage($scope.tr('emailpro_tab_domain_modify_success'), 'true');
         })
         .catch((failure) => {
           // Make sure the type in the select widget is reset to its initial value
           $rootScope.$broadcast(EmailPro.events.domainsChanged);
-          $scope.setMessage($scope.tr('exchange_tab_domain_modify_failure'), failure.data);
+          $scope.setMessage($scope.tr('emailpro_tab_domain_modify_failure'), failure.data);
         });
     };
 

--- a/src/emailpro/domain/update/emailpro-domain-update.html
+++ b/src/emailpro/domain/update/emailpro-domain-update.html
@@ -3,7 +3,7 @@
          data-wizard-bread-crumb
          data-wizard-on-cancel="cancel"
          data-wizard-on-finish="submit"
-         data-wizard-title="i18n.exchange_tab_domain_modify_domain">
+         data-wizard-title="i18n.emailpro_tab_domain_modify_domain">
 
         <div data-wizard-step
              data-wizard-step-valid="isValid()">
@@ -16,20 +16,20 @@
 
                 <div class="form-group">
                     <label class="col-md-4 control-label"
-                           data-i18n-static="exchange_tab_domain_domain"></label>
+                           data-i18n-static="emailpro_tab_domain_domain"></label>
                     <div class="col-md-8">
                         <p class="form-control-static" data-ng-bind="currentActionData.displayName"></p>
                     </div>
                 </div>
                 <div class="form-group">
                     <label for="type" class="col-md-4 control-label"
-                           data-i18n-static="exchange_tab_domain_type"></label>
+                           data-i18n-static="emailpro_tab_domain_type"></label>
                     <div class="col-md-8">
                         <div class="oui-select">
                             <select class="oui-select__input"
                                 id="type"
                                 name="type"
-                                data-ng-options="tr('exchange_tab_domain_' + type) for type in domainTypes"
+                                data-ng-options="tr('emailpro_tab_domain_' + type) for type in domainTypes"
                                 data-ng-model="selectedDomain.type"
                                 data-ng-change="checkMxRelay()">
                             </select>
@@ -41,20 +41,20 @@
                      data-ng-if="isMxRelayVisible() && selectedDomain.type === 'NON_AUTHORITATIVE'"
                      data-ng-class="{ 'has-error': !isValidMxRelay() || checkLoopWarning() || checkLengthWarning() }">
                     <label for="selectedDomain" class="col-md-4 control-label required"
-                           data-i18n-static="exchange_tab_domain_add_step2_mx_replay"></label>
+                           data-i18n-static="emailpro_tab_domain_add_step2_mx_replay"></label>
                     <div class="col-md-8">
                         <input type="text" class="form-control" id="selectedDomain" name="selectedDomain"
                                data-ng-model="selectedDomain.mxRelay"
                                data-ng-pattern="/^([-a-zA-Z0-9\.])+$/">
                         <span class="help-block"
                               data-ng-hide="isValidMxRelay()"
-                              data-i18n-static="exchange_tab_domain_modify_domain_warning"></span>
+                              data-i18n-static="emailpro_tab_domain_modify_domain_warning"></span>
                         <span class="help-block"
                               data-ng-show="checkLoopWarning()"
-                              data-i18n-static="exchange_tab_domain_modify_loop_warning"></span>
+                              data-i18n-static="emailpro_tab_domain_modify_loop_warning"></span>
                         <span class="help-block"
                               data-ng-show="checkLengthWarning()"
-                              data-i18n-static="exchange_tab_domain_modify_length_warning"></span>
+                              data-i18n-static="emailpro_tab_domain_modify_length_warning"></span>
                     </div>
                 </div>
                 <p data-ng-show="selectedDomain.type === 'NON_AUTHORITATIVE' && exchange"
@@ -62,8 +62,8 @@
             </form>
 
             <div data-wizard-step-help>
-                <h3 data-i18n-static="exchange_tab_domain_modify_domain"></h3>
-                <h4 data-i18n-static="exchange_tab_domain_modify_wizard_subtitle"></h4>
+                <h3 data-i18n-static="emailpro_tab_domain_modify_domain"></h3>
+                <h4 data-i18n-static="emailpro_tab_domain_modify_wizard_subtitle"></h4>
                 <p data-ng-bind-html="tr('emailpro_tab_domain_modify_wizard_text')"></p>
             </div>
 
@@ -73,17 +73,17 @@
             <p data-i18n-static="emailpro_tab_domain_modify_title"></p>
 
             <dl class="dl-horizontal">
-                <dt data-i18n-static="exchange_tab_domain_domain"></dt>
+                <dt data-i18n-static="emailpro_tab_domain_domain"></dt>
                 <dd data-ng-bind="currentActionData.displayName"></dd>
 
                 <div data-ng-if="isMxRelayVisible() && selectedDomain.type == 'NON_AUTHORITATIVE'">
-                    <dt data-i18n-static="exchange_tab_domain_add_step2_mx_replay"></dt>
+                    <dt data-i18n-static="emailpro_tab_domain_add_step2_mx_replay"></dt>
                     <dd data-ng-bind="selectedDomain.mxRelay" data-ng-if="selectedDomain.mxRelay"></dd>
                     <dd data-ng-if="!selectedDomain.mxRelay">-</dd>
                 </div>
 
-                <dt data-i18n-static="exchange_tab_domain_type"></dt>
-                <dd data-ng-bind="tr('exchange_tab_domain_' + selectedDomain.type)"></dd>
+                <dt data-i18n-static="emailpro_tab_domain_type"></dt>
+                <dd data-ng-bind="tr('emailpro_tab_domain_' + selectedDomain.type)"></dd>
             </dl>
             <p data-ng-show="selectedDomain.type == 'NON_AUTHORITATIVE' && exchange"
                data-ng-bind-html="tr('emailpro_tab_domain_modify_domain_tooltip', [nonAuthoritativeEmail[0], nonAuthoritativeEmail[1], nonAuthoritativeEmail[2], nonAuthoritativeEmail[3], exchange.hostname])"></p>

--- a/src/emailpro/emailpro-tabs-controller.js
+++ b/src/emailpro/emailpro-tabs-controller.js
@@ -13,12 +13,12 @@ angular.module('Module.emailpro.controllers').controller('EmailProTabsCtrl', ($s
     title: $scope.tr('navigation_more'),
     items: [
       {
-        label: $scope.tr('exchange_tab_DISCLAIMER'),
+        label: $scope.tr('emailpro_tab_DISCLAIMER'),
         target: 'DISCLAIMER',
         type: 'SWITCH_TABS',
       },
       {
-        label: $scope.tr('exchange_tab_TASKS'),
+        label: $scope.tr('emailpro_tab_TASKS'),
         target: 'TASK',
         type: 'SWITCH_TABS',
       },

--- a/src/emailpro/emailpro.controller.js
+++ b/src/emailpro/emailpro.controller.js
@@ -44,32 +44,32 @@ angular.module('Module.emailpro.controllers').controller('EmailProCtrl', [
 
     const loadATooltip = function (exchange) {
       if (exchange.serverDiagnostic.ip && exchange.serverDiagnostic.isAValid) {
-        _.set(exchange, 'serverDiagnostic.aTooltip', $scope.tr('exchange_dashboard_diag_a_tooltip_ok'));
+        _.set(exchange, 'serverDiagnostic.aTooltip', $scope.tr('emailpro_dashboard_diag_a_tooltip_ok'));
       } else {
-        _.set(exchange, 'serverDiagnostic.aTooltip', $scope.tr('exchange_dashboard_diag_a_tooltip_error', [exchange.hostname, exchange.serverDiagnostic.ip]));
+        _.set(exchange, 'serverDiagnostic.aTooltip', $scope.tr('emailpro_dashboard_diag_a_tooltip_error', [exchange.hostname, exchange.serverDiagnostic.ip]));
       }
     };
 
     const loadAaaaTooltip = function (exchange) {
       if (exchange.serverDiagnostic.ipV6 && exchange.serverDiagnostic.isAaaaValid) {
-        _.set(exchange, 'serverDiagnostic.aaaaTooltip', $scope.tr('exchange_dashboard_diag_aaaa_tooltip_ok'));
+        _.set(exchange, 'serverDiagnostic.aaaaTooltip', $scope.tr('emailpro_dashboard_diag_aaaa_tooltip_ok'));
       } else {
-        _.set(exchange, 'serverDiagnostic.aaaaTooltip', $scope.tr('exchange_dashboard_diag_aaaa_tooltip_error', [exchange.hostname, exchange.serverDiagnostic.ipV6]));
+        _.set(exchange, 'serverDiagnostic.aaaaTooltip', $scope.tr('emailpro_dashboard_diag_aaaa_tooltip_error', [exchange.hostname, exchange.serverDiagnostic.ipV6]));
       }
     };
 
     const loadPtrTooltip = function (exchange) {
       if (exchange.serverDiagnostic.isPtrValid) {
-        _.set(exchange, 'serverDiagnostic.ptrTooltip', $scope.tr('exchange_dashboard_diag_ptr_tooltip_ok'));
+        _.set(exchange, 'serverDiagnostic.ptrTooltip', $scope.tr('emailpro_dashboard_diag_ptr_tooltip_ok'));
       } else {
-        _.set(exchange, 'serverDiagnostic.ptrTooltip', $scope.tr('exchange_dashboard_diag_ptr_tooltip_error'));
+        _.set(exchange, 'serverDiagnostic.ptrTooltip', $scope.tr('emailpro_dashboard_diag_ptr_tooltip_error'));
       }
     };
     const loadPtrv6Tooltip = function (exchange) {
       if (exchange.serverDiagnostic.isPtrV6Valid) {
-        _.set(exchange, 'serverDiagnostic.ptrv6Tooltip', $scope.tr('exchange_dashboard_diag_ptrv6_tooltip_ok'));
+        _.set(exchange, 'serverDiagnostic.ptrv6Tooltip', $scope.tr('emailpro_dashboard_diag_ptrv6_tooltip_ok'));
       } else {
-        _.set(exchange, 'serverDiagnostic.ptrv6Tooltip', $scope.tr('exchange_dashboard_diag_ptrv6_tooltip_error'));
+        _.set(exchange, 'serverDiagnostic.ptrv6Tooltip', $scope.tr('emailpro_dashboard_diag_ptrv6_tooltip_error'));
       }
     };
 
@@ -89,7 +89,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProCtrl', [
           $scope.loadingEmailProInformations = false;
 
           if (exchange.messages && exchange.messages.length > 0) {
-            $scope.setMessage($scope.tr('exchange_dashboard_loading_error'), exchange);
+            $scope.setMessage($scope.tr('emailpro_dashboard_loading_error'), exchange);
             if (!exchange.name) {
               $scope.loadingEmailProError = true;
             }
@@ -127,7 +127,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProCtrl', [
             if (response.code === 460 || response.status === 460) {
               $scope.setMessage($scope.tr('common_service_expired', [response.id]), data);
             } else {
-              $scope.setMessage($scope.tr('exchange_dashboard_loading_error'), data);
+              $scope.setMessage($scope.tr('emailpro_dashboard_loading_error'), data);
             }
           }
         });
@@ -339,7 +339,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProCtrl', [
       $timeout(() => {
         $scope.edit.active = false;
         if ($scope.newDisplayName.value.length < 5) {
-          $scope.setMessage($scope.tr('exchange_dashboard_display_name_min'));
+          $scope.setMessage($scope.tr('emailpro_dashboard_display_name_min'));
         }
       }, 300);
     };
@@ -355,9 +355,9 @@ angular.module('Module.emailpro.controllers').controller('EmailProCtrl', [
         }).then(() => {
           $scope.exchange.displayName = $scope.newDisplayName.value;
           $rootScope.$broadcast('change.displayName', [$scope.exchange.domain, $scope.newDisplayName.value]);
-          $scope.setMessage($scope.tr('exchange_ACTION_configure_success'), 'true');
+          $scope.setMessage($scope.tr('emailpro_ACTION_configure_success'), 'true');
         }).catch((err) => {
-          $scope.setMessage($scope.tr('exchange_ACTION_configure_error'), _.get(err, 'data', ''));
+          $scope.setMessage($scope.tr('emailpro_ACTION_configure_error'), _.get(err, 'data', ''));
         }).finally(() => {
           $scope.edit.active = false;
         });
@@ -391,7 +391,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProRemoveEmailPro
   $scope.EmailPro2013Code = EmailPro.EmailPro2013Code;
 
   $scope.getSubmitButtonLabel = function () {
-    return $scope.exchange.deleteAtExpirationValue ? $scope.tr('exchange_resilitation_action_button') : $scope.tr('exchange_resilitation_cancel_action_button');
+    return $scope.exchange.deleteAtExpirationValue ? $scope.tr('emailpro_resilitation_action_button') : $scope.tr('emailpro_resilitation_cancel_action_button');
   };
 
   $scope.submit = function () {
@@ -403,13 +403,13 @@ angular.module('Module.emailpro.controllers').controller('EmailProRemoveEmailPro
         if ($scope.exchange.renewType.deleteAtExpiration) {
           updateRenewMessages = {
             OK: $scope.tr('emailpro_resilitation_cancel_action_success'),
-            PARTIAL: $scope.tr('exchange_resilitation_cancel_action_partial'),
-            ERROR: $scope.tr('exchange_resilitation_cancel_action_failure'),
+            PARTIAL: $scope.tr('emailpro_resilitation_cancel_action_partial'),
+            ERROR: $scope.tr('emailpro_resilitation_cancel_action_failure'),
           };
         } else {
           updateRenewMessages = {
             OK: $scope.tr('emailpro_resilitation_action_success'),
-            PARTIAL: $scope.tr('exchange_resilitation_action_partial'),
+            PARTIAL: $scope.tr('emailpro_resilitation_action_partial'),
             ERROR: $scope.tr('emailpro_resilitation_action_failure'),
           };
         }
@@ -418,7 +418,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProRemoveEmailPro
       })
       .catch((failure) => {
         if ($scope.exchange.renewType.deleteAtExpiration) {
-          $scope.setMessage($scope.tr('exchange_resilitation_cancel_action_failure'), failure.data);
+          $scope.setMessage($scope.tr('emailpro_resilitation_cancel_action_failure'), failure.data);
         } else {
           $scope.setMessage($scope.tr('emailpro_resilitation_action_failure'), failure.data);
         }

--- a/src/emailpro/emailpro.html
+++ b/src/emailpro/emailpro.html
@@ -61,7 +61,7 @@
                     <button class="btn btn-link" type="button"
                               data-ng-if="exchange.renewOptionAvailable || is25g()"
                               data-ng-click="setAction('emailpro/update/renew/emailpro-update-renew', exchange)"
-                              data-i18n-static="exchange_update_billing_button_title">
+                              data-i18n-static="emailpro_update_billing_button_title">
                     </button>
                   </li>
                   <li class="dropdown-divider">
@@ -69,8 +69,8 @@
                       <button class="btn btn-link" type="button"
                               data-ng-if="exchange.deleteOptionAvailable"
                               data-ng-click="setAction('emailpro/remove/emailpro-remove', exchange)">
-                          <span data-i18n-static="exchange_resilitation_action_button" data-ng-if="!exchange.renewType.deleteAtExpiration"></span>
-                          <span data-i18n-static="exchange_resilitation_action_button_cancel" data-ng-if="exchange.renewType.deleteAtExpiration"></span>
+                          <span data-i18n-static="emailpro_resilitation_action_button" data-ng-if="!exchange.renewType.deleteAtExpiration"></span>
+                          <span data-i18n-static="emailpro_resilitation_action_button_cancel" data-ng-if="exchange.renewType.deleteAtExpiration"></span>
                       </button>
                   </li>
                 </ul>
@@ -99,7 +99,7 @@
                  data-linkedpopover-single="false"
                  data-linkedpopover-remote="true">
                 <strong class="pointer underline"
-                        data-i18n-static="exchange_dashboard_message_see_more"
+                        data-i18n-static="emailpro_dashboard_message_see_more"
                         data-ng-if="messageDetails.length > 0"></strong>
             </div>
         </div>
@@ -120,7 +120,7 @@
              data-linkedpopover-single="false"
              data-linkedpopover-remote="true">
             <strong class="pointer underline"
-                    data-i18n-static="exchange_dashboard_message_see_more"
+                    data-i18n-static="emailpro_dashboard_message_see_more"
                     data-ng-if="messageDetails.length > 0"></strong>
         </div>
     </div>
@@ -130,8 +130,8 @@
 <div class="alert alert-warning mt-5 mx-5" role="alert"
      data-ng-if="exchange.serverDiagnostic.individual2010"
      data-ng-show="!loadingEmailProInformations && !loadingEmailProError">
-    <a href="http://migrationstatus.mail.ovh.net" target="_blank" title="{{tr('exchange_dashboard_2016_migration')}} ({{tr('exchange_dashboard_new_window')}})">
-        <span data-i18n-static="exchange_dashboard_2016_migration"></span>
+    <a href="http://migrationstatus.mail.ovh.net" target="_blank" title="{{tr('emailpro_dashboard_2016_migration')}} ({{tr('emailpro_dashboard_new_window')}})">
+        <span data-i18n-static="emailpro_dashboard_2016_migration"></span>
         <span class="fa fa-external-link ml-2" aria-hidden="true"></span>
     </a>
 </div>

--- a/src/emailpro/external-contact/add/emailpro-external-contact-add.html
+++ b/src/emailpro/external-contact/add/emailpro-external-contact-add.html
@@ -3,13 +3,13 @@
          data-wizard-bread-crumb
          data-wizard-on-cancel="resetAction"
          data-wizard-on-finish="addContact"
-         data-wizard-title="i18n.exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_title">
+         data-wizard-title="i18n.emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_title">
 
         <div data-wizard-step
              data-wizard-step-on-load="init"
              data-wizard-step-valid="accountIsValid()">
 
-            <p class="mb-3" data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_question"></p>
+            <p class="mb-3" data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_question"></p>
             <form class="form-horizontal" name="externalContactAddForm">
                 <p>
                     <small class="text-danger">*</small>
@@ -17,18 +17,18 @@
                 </p>
                 <div class="form-group" data-ng-class="getPasswordInvalidClass()">
                     <label for="emailAddress" class="control-label col-md-3 required"
-                           data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_email_label"></label>
+                           data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_email_label"></label>
                     <div class="col-md-9">
                         <input class="oui-input" id="emailAddress" type="text"
                                data-ng-model="model.newAccount.externalEmailAddress">
                         <span class="help-block text-danger"
                               data-ng-if="!isEmailValid() && model.newAccount.externalEmailAddress"
-                              data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_email_invalid"></span>
+                              data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_email_invalid"></span>
                     </div>
                 </div>
                 <div class="form-group" data-ng-if="availableMainDomains">
                     <label for="availableMainDomain" class="control-label col-md-3 required"
-                           data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_organization2010_label"></label>
+                           data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_organization2010_label"></label>
                     <div class="col-md-9">
                         <select class="form-control input-group-addon" id="availableMainDomain" required
                                 data-ng-options="domain.displayName for domain in availableMainDomains"
@@ -38,7 +38,7 @@
                 </div>
                 <div class="form-group">
                     <label for="displayName" class="control-label col-md-3 required"
-                           data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_display_name_label"></label>
+                           data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_display_name_label"></label>
                     <div class="col-md-9">
                         <input type="text" class="oui-input" id="displayName" required
                                data-ng-model="model.newAccount.displayName"
@@ -47,7 +47,7 @@
                 </div>
                 <div class="form-group">
                     <label for="firstName" class="control-label col-md-3"
-                           data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_first_name_label"></label>
+                           data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_first_name_label"></label>
                     <div class="col-md-9">
                         <input type="text" class="oui-input" id="firstName" max="64"
                                data-ng-model="model.newAccount.firstName"
@@ -56,7 +56,7 @@
                 </div>
                 <div class="form-group">
                     <label for="lastName" class="control-label col-md-3"
-                           data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_last_name_label"></label>
+                           data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_last_name_label"></label>
                     <div class="col-md-9">
                         <input type="text" class="oui-input" id="lastName" max="64"
                                data-ng-model="model.newAccount.lastName"
@@ -66,24 +66,24 @@
             </form>
 
             <div data-wizard-step-help>
-                <h3 data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_wizardhelp_requirements_title"></h3>
-                <p data-ng-bind-html="tr('exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_wizardhelp_requirements_content')"></p>
+                <h3 data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_wizardhelp_requirements_title"></h3>
+                <p data-ng-bind-html="tr('emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_wizardhelp_requirements_content')"></p>
             </div>
         </div>
 
         <div data-wizard-step>
-            <p data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_step2_question"></p>
+            <p data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step2_question"></p>
             <dl class="dl-horizontal">
-                <dt data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_step2_email_label"></dt>
+                <dt data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step2_email_label"></dt>
                 <dd data-ng-bind="model.newAccount.externalEmailAddress"></dd>
 
-                <dt data-ng-if="model.newAccount.firstName" data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_step2_first_name_label"></dt>
+                <dt data-ng-if="model.newAccount.firstName" data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step2_first_name_label"></dt>
                 <dd data-ng-if="model.newAccount.firstName" data-ng-bind="model.newAccount.firstName"></dd>
 
-                <dt data-ng-if="model.newAccount.lastName" data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_step2_last_name_label"></dt>
+                <dt data-ng-if="model.newAccount.lastName" data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step2_last_name_label"></dt>
                 <dd data-ng-if="model.newAccount.lastName" data-ng-bind="model.newAccount.lastName"></dd>
 
-                <dt data-ng-if="model.newAccount.displayName" data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_step2_display_name_label"></dt>
+                <dt data-ng-if="model.newAccount.displayName" data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step2_display_name_label"></dt>
                 <dd data-ng-if="model.newAccount.displayName" data-ng-bind="model.newAccount.displayName"></dd>
             </dl>
         </div>

--- a/src/emailpro/external-contact/emailpro-external-contact-table-line-template.html
+++ b/src/emailpro/external-contact/emailpro-external-contact-table-line-template.html
@@ -12,11 +12,11 @@
     <span data-ng-hide="element.state == 'OK'"
         class="label"
         data-ng-class="getStateClassFor(element.state)"
-        data-ng-bind="tr('exchange_tab_EXTERNAL_CONTACTS_table_headers_state_' + element.state)">
+        data-ng-bind="tr('emailpro_tab_EXTERNAL_CONTACTS_table_headers_state_' + element.state)">
     </span>
     <span data-ng-show="element.state == 'OK' && element.taskPendingId"
         class="label label-info"
-        data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_MODIFYING">
+        data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_table_headers_state_MODIFYING">
     </span>
 </div>
 

--- a/src/emailpro/external-contact/emailpro-external-contact-table.popover.html
+++ b/src/emailpro/external-contact/emailpro-external-contact-table.popover.html
@@ -1,11 +1,11 @@
 <div class="popover-menu">
     <button class="btn btn-link btn-block text-left" type="button"
-            data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_table_actions_menu_modify"
+            data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_table_actions_menu_modify"
             data-ng-click="modifyExternalContact(element)"
             data-ng-disabled="getIsDisabled(element)">
     </button>
     <button class="btn btn-link btn-block text-left" type="button"
-            data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_table_actions_menu_delete"
+            data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_table_actions_menu_delete"
             data-ng-click="deleteExternalContact(element)"
             data-ng-disabled="getIsDisabled(element)">
     </button>

--- a/src/emailpro/external-contact/emailpro-external-contact.controller.js
+++ b/src/emailpro/external-contact/emailpro-external-contact.controller.js
@@ -18,7 +18,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProAddExternalCon
           })
           .catch((failure) => {
             $scope.resetAction();
-            $scope.setMessage($scope.tr('exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_fail'), failure.data);
+            $scope.setMessage($scope.tr('emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_fail'), failure.data);
           });
       }
     });
@@ -43,11 +43,11 @@ angular.module('Module.emailpro.controllers').controller('EmailProAddExternalCon
     EmailProExternalContacts
       .addContact($stateParams.organization, $stateParams.productId, $scope.model.newAccount)
       .then(() => {
-        $scope.setMessage($scope.tr('exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_success'), { status: 'success' });
+        $scope.setMessage($scope.tr('emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_success'), { status: 'success' });
       })
       .catch((failure) => {
         _.set(failure, 'status', 'error');
-        $scope.setMessage($scope.tr('exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_fail'), failure);
+        $scope.setMessage($scope.tr('emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_fail'), failure);
       });
   };
 
@@ -107,10 +107,10 @@ angular.module('Module.emailpro.controllers').controller('EmailProExternalContac
         $scope.model.newAccount,
       )
       .then(() => {
-        $scope.setMessage($scope.tr('exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_success'), { status: 'success' });
+        $scope.setMessage($scope.tr('emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_success'), { status: 'success' });
       }, (err) => {
         _.set(err, 'status', err.status || 'error');
-        $scope.setMessage($scope.tr('exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_fail'), err);
+        $scope.setMessage($scope.tr('emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_fail'), err);
       });
   };
 
@@ -158,11 +158,11 @@ angular.module('Module.emailpro.controllers').controller('EmailProExternalContac
         $scope.model.externalEmailAddress,
       )
       .then(() => {
-        $scope.setMessage($scope.tr('exchange_tab_EXTERNAL_CONTACTS_configuration_contact_delete_success'), { status: 'success' });
+        $scope.setMessage($scope.tr('emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_delete_success'), { status: 'success' });
       })
       .catch((err) => {
         _.set(err, 'status', err.status || 'error');
-        $scope.setMessage($scope.tr('exchange_tab_EXTERNAL_CONTACTS_configuration_contact_delete_fail'), err);
+        $scope.setMessage($scope.tr('emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_delete_fail'), err);
       });
   };
 });

--- a/src/emailpro/external-contact/emailpro-external-contact.html
+++ b/src/emailpro/external-contact/emailpro-external-contact.html
@@ -5,7 +5,7 @@
             <div class="text-right mb-3">
                 <form class="form-inline">
                     <div class="input-group">
-                        <input type="text" class="form-control" placeholder="{{i18n.exchange_tab_EXTERNAL_CONTACTS_search_placeholder}}"
+                        <input type="text" class="form-control" placeholder="{{i18n.emailpro_tab_EXTERNAL_CONTACTS_search_placeholder}}"
                                data-ng-model="filter">
                         <div class="input-group-btn"
                              data-ng-if="filter">
@@ -26,11 +26,11 @@
                 <table class="table table-hover">
                     <thead>
                         <tr>
-                            <th scope="col" data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_table_headers_externalEmailAddress"></th>
-                            <th class="text-center" scope="col" data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_table_headers_displayName"></th>
-                            <th class="text-center" scope="col" data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_table_headers_creationDate"></th>
-                            <th class="text-center" scope="col" data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_table_headers_hiddenFromGAL"></th>
-                            <th class="text-center" scope="col" data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_table_headers_state"></th>
+                            <th scope="col" data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_table_headers_externalEmailAddress"></th>
+                            <th class="text-center" scope="col" data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_table_headers_displayName"></th>
+                            <th class="text-center" scope="col" data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_table_headers_creationDate"></th>
+                            <th class="text-center" scope="col" data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_table_headers_hiddenFromGAL"></th>
+                            <th class="text-center" scope="col" data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_table_headers_state"></th>
                             <th class="min-width" scope="col"></th>
                         </tr>
                     </thead>
@@ -44,7 +44,7 @@
                     <tbody data-ng-if="!contactsLoading && !contacts.list.results.length">
                         <tr>
                             <td class="text-center" colspan="6"
-                                data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_table_empty"></td>
+                                data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_table_empty"></td>
                         </tr>
                     </tbody>
 
@@ -58,7 +58,7 @@
 
                             <td class="text-center">
                                 <span class="btn btn-icon"
-                                      data-uib-tooltip="{{tr('exchange_tab_EXTERNAL_CONTACTS_table_tooltip_GAL_' + element.hiddenFromGAL)}}"
+                                      data-uib-tooltip="{{tr('emailpro_tab_EXTERNAL_CONTACTS_table_tooltip_GAL_' + element.hiddenFromGAL)}}"
                                       data-tooltip-append-to-body="true">
                                     <span class="oui-icon oui-icon_small"
                                           data-ng-class="{ 'oui-icon-success text-success': !element.hiddenFromGAL, 'oui-icon-error text-danger': element.hiddenFromGAL }">
@@ -68,12 +68,12 @@
 
                             <td class="text-center">
                                 <span class="label"
-                                      data-ng-bind="tr('exchange_tab_EXTERNAL_CONTACTS_table_headers_state_' + element.state)"
+                                      data-ng-bind="tr('emailpro_tab_EXTERNAL_CONTACTS_table_headers_state_' + element.state)"
                                       data-ng-class="getStateClassFor(element.state)"
                                       data-ng-if="element.state !== 'OK'">
                                 </span>
                                 <span class="label label-info"
-                                      data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_table_headers_state_MODIFYING"
+                                      data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_table_headers_state_MODIFYING"
                                       data-ng-if="element.state === 'OK' && element.taskPendingId">
                                 </span>
                             </td>
@@ -104,7 +104,7 @@
 
         <div class="col-md-3 mt-5 mt-lg-0">
             <button type="button" class="btn btn-block btn-default"
-                    data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_add_title_button"
+                    data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_title_button"
                     data-ng-click="setAction('emailpro/external-contact/add/emailpro-external-contact-add')">
             </button>
         </div>

--- a/src/emailpro/external-contact/remove/emailpro-external-contact-remove.html
+++ b/src/emailpro/external-contact/remove/emailpro-external-contact-remove.html
@@ -2,12 +2,12 @@
     <div data-wizard
          data-wizard-on-cancel="resetAction"
          data-wizard-on-finish="deleteAccount"
-         data-wizard-title="i18n.exchange_tab_EXTERNAL_CONTACTS_configuration_contact_delete_title">
+         data-wizard-title="i18n.emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_delete_title">
 
         <div data-wizard-step>
-            <p data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_delete_step1_question"></p>
+            <p data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_delete_step1_question"></p>
             <dl>
-                <dt data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_delete_step1_contact"></dt>
+                <dt data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_delete_step1_contact"></dt>
                 <dd data-ng-bind="model.externalEmailAddress"></dd>
             </dl>
         </div>

--- a/src/emailpro/external-contact/update/emailpro-external-contact-update.html
+++ b/src/emailpro/external-contact/update/emailpro-external-contact-update.html
@@ -3,11 +3,11 @@
          data-wizard-bread-crumb
          data-wizard-on-cancel="resetAction"
          data-wizard-on-finish="modifyContact"
-         data-wizard-title="i18n.exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_title">
+         data-wizard-title="i18n.emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_title">
 
         <div data-wizard-step
              data-wizard-step-valid="accountIsValid()">
-            <p class="mb-3" data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_question"></p>
+            <p class="mb-3" data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_question"></p>
             <form class="form-horizontal" name="emailProExternalContactsModifyForm">
                 <p>
                     <small class="text-danger">*</small>
@@ -16,18 +16,18 @@
                 <div class="form-group" data-ng-class="getPasswordInvalidClass()">
                     <label for="emailAddress"
                            class="control-label col-md-3 required"
-                           data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_email_label"></label>
+                           data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_email_label"></label>
                     <div class="col-md-9">
                         <input type="text" class="oui-input" id="emailAddress" required
                                data-ng-model="model.newAccount.externalEmailAddress">
                         <span class="help-block text-danger"
                               data-ng-if="!isEmailValid() && model.newAccount.externalEmailAddress"
-                              data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_email_invalid"></span>
+                              data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_email_invalid"></span>
                     </div>
                 </div>
                 <div class="form-group">
                     <label for="firstName" class="control-label col-md-3"
-                           data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_first_name_label"></label>
+                           data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_first_name_label"></label>
                     <div class="col-md-9">
                         <input type="text" class="oui-input" id="firstName" max="64"
                                data-ng-model="model.newAccount.firstName"
@@ -36,7 +36,7 @@
                 </div>
                 <div class="form-group">
                     <label for="lastName" class="control-label col-md-3"
-                           data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_last_name_label"></label>
+                           data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_last_name_label"></label>
                     <div class="col-md-9">
                         <input type="text" class="oui-input" id="lastName" max="64"
                                data-ng-model="model.newAccount.lastName"
@@ -45,7 +45,7 @@
                 </div>
                 <div class="form-group">
                     <label for="displayName" class="control-label col-md-3 required"
-                           data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_display_name_label"></label>
+                           data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_display_name_label"></label>
                     <div class="col-md-9">
                         <input type="text" class="oui-input" id="displayName" required
                                data-ng-model="model.newAccount.displayName"
@@ -55,24 +55,24 @@
             </form>
 
             <div data-wizard-step-help>
-                <h3 data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_wizardhelp_requirements_title"></h3>
-                <p data-ng-bind-html="tr('exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_wizardhelp_requirements_content')"></p>
+                <h3 data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_wizardhelp_requirements_title"></h3>
+                <p data-ng-bind-html="tr('emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_wizardhelp_requirements_content')"></p>
             </div>
         </div>
 
         <div data-wizard-step>
-            <p data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step2_question"></p>
+            <p data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step2_question"></p>
             <dl class="dl-horizontal">
-                <dt data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step2_email_label"></dt>
+                <dt data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step2_email_label"></dt>
                 <dd data-ng-bind="model.newAccount.externalEmailAddress"></dd>
 
-                <dt data-ng-if="model.newAccount.firstName" data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step2_first_name_label"></dt>
+                <dt data-ng-if="model.newAccount.firstName" data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step2_first_name_label"></dt>
                 <dd data-ng-if="model.newAccount.firstName" data-ng-bind="model.newAccount.firstName"></dd>
 
-                <dt data-ng-if="model.newAccount.lastName" data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step2_last_name_label"></dt>
+                <dt data-ng-if="model.newAccount.lastName" data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step2_last_name_label"></dt>
                 <dd data-ng-if="model.newAccount.lastName" data-ng-bind="model.newAccount.lastName"></dd>
 
-                <dt data-ng-if="model.newAccount.displayName" data-i18n-static="exchange_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step2_display_name_label"></dt>
+                <dt data-ng-if="model.newAccount.displayName" data-i18n-static="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step2_display_name_label"></dt>
                 <dd data-ng-if="model.newAccount.displayName" data-ng-bind="model.newAccount.displayName"></dd>
             </dl>
         </div>

--- a/src/emailpro/information/emailpro-information.html
+++ b/src/emailpro/information/emailpro-information.html
@@ -5,13 +5,13 @@
             <div class="row d-md-flex">
                 <div class="col-sm-6 mb-5">
                     <div class="oui-tile h-100">
-                        <h3 class="oui-tile__title" data-i18n-static="exchange_tab_INFORMATIONS_summary"></h3>
+                        <h3 class="oui-tile__title" data-i18n-static="emailpro_tab_INFORMATIONS_summary"></h3>
                         <div class="oui-tile__body">
                             <ul class="list-unstyled">
                                 <li class="oui-tile__item">
                                     <div class="oui-tile__definition">
                                         <strong class="d-block"
-                                                data-i18n-static="exchange_dashboard_name"></strong>
+                                                data-i18n-static="emailpro_dashboard_name"></strong>
                                         <span data-ng-bind="exchange.domain"></span>
                                     </div>
                                 </li>
@@ -19,40 +19,40 @@
                                     class="oui-tile__item">
                                     <div class="oui-tile__definition">
                                         <strong class="d-block"
-                                                data-i18n-static="exchange_dashboard_diag"></strong>
+                                                data-i18n-static="emailpro_dashboard_diag"></strong>
                                         <span class="mt-2 d-inline-block pointer">
                                             <span data-ng-if="!exchange.offer == !accountTypeProvider"
                                                   data-ng-class="{'label label-success': exchange.serverDiagnostic.isAValid,
                                                                   'label label-danger': !exchange.serverDiagnostic.isAValid}"
                                                   data-simplepopover="{{exchange.serverDiagnostic.aTooltip}}"
-                                                  data-simplepopover-title="{{tr('exchange_dashboard_diag_a_tooltip_title')}}"
+                                                  data-simplepopover-title="{{tr('emailpro_dashboard_diag_a_tooltip_title')}}"
                                                   data-simplepopover-placement="right"
                                                   data-simplepopover-single="true"
-                                                  data-i18n-static="exchange_dashboard_diag_a_label"></span>
+                                                  data-i18n-static="emailpro_dashboard_diag_a_label"></span>
                                             <span data-ng-if="exchange.offer == accountTypeDedicated"
                                                   data-ng-class="{'label label-success': exchange.serverDiagnostic.isAaaaValid,
                                                                   'label label-danger': !exchange.serverDiagnostic.isAaaaValid}"
                                                   data-simplepopover="{{exchange.serverDiagnostic.aaaaTooltip}}"
-                                                  data-simplepopover-title="{{tr('exchange_dashboard_diag_aaaa_tooltip_title')}}"
+                                                  data-simplepopover-title="{{tr('emailpro_dashboard_diag_aaaa_tooltip_title')}}"
                                                   data-simplepopover-placement="bottom"
                                                   data-simplepopover-single="true"
-                                                  data-i18n-static="exchange_dashboard_diag_aaaa_label"></span>
+                                                  data-i18n-static="emailpro_dashboard_diag_aaaa_label"></span>
                                             <span data-ng-if="exchange.offer == accountTypeDedicated"
                                                   data-ng-class="{'label label-success': exchange.serverDiagnostic.isPtrValid,
                                                                   'label label-danger': !exchange.serverDiagnostic.isPtrValid}"
                                                   data-simplepopover="{{exchange.serverDiagnostic.ptrTooltip}}"
-                                                  data-simplepopover-title="{{tr('exchange_dashboard_diag_ptr_tooltip_title')}}"
+                                                  data-simplepopover-title="{{tr('emailpro_dashboard_diag_ptr_tooltip_title')}}"
                                                   data-simplepopover-placement="bottom"
                                                   data-simplepopover-single="true"
-                                                  data-i18n-static="exchange_dashboard_diag_ptr_label"></span>
+                                                  data-i18n-static="emailpro_dashboard_diag_ptr_label"></span>
                                             <span data-ng-if="exchange.offer == accountTypeDedicated"
                                                   data-ng-class="{'label label-success': exchange.serverDiagnostic.isPtrV6Valid,
                                                                   'label label-danger': !exchange.serverDiagnostic.isPtrV6Valid}"
                                                   data-simplepopover="{{exchange.serverDiagnostic.ptrv6Tooltip}}"
-                                                  data-simplepopover-title="{{tr('exchange_dashboard_diag_ptrv6_tooltip_title')}}"
+                                                  data-simplepopover-title="{{tr('emailpro_dashboard_diag_ptrv6_tooltip_title')}}"
                                                   data-simplepopover-placement="bottom"
                                                   data-simplepopover-single="true"
-                                                  data-i18n-static="exchange_dashboard_diag_ptrv6_label">
+                                                  data-i18n-static="emailpro_dashboard_diag_ptrv6_label">
                                             </span>
                                         </span>
                                     </div>
@@ -62,10 +62,10 @@
                                     <div class="oui-tile__definition">
                                         <strong class="d-block"
                                                 data-ng-if="exchange.sslExpirationDate"
-                                                data-i18n-static="exchange_dashboard_ssl_expiration"></strong>
+                                                data-i18n-static="emailpro_dashboard_ssl_expiration"></strong>
                                         <strong class="d-block"
                                                 data-ng-if="displayRenewDate()"
-                                                data-i18n-static="exchange_dashboard_expiration"></strong>
+                                                data-i18n-static="emailpro_dashboard_expiration"></strong>
                                         <span data-ng-if="displayRenewDate()"
                                               data-ng-bind="exchange.expiration | date:'mediumDate'"></span>
                                     </div>
@@ -76,12 +76,12 @@
                 </div>
                 <div class="col-sm-6 mb-5">
                     <div class="oui-tile h-100">
-                        <h3 class="oui-tile__title" data-i18n-static="exchange_tab_INFORMATIONS_stats"></h3>
+                        <h3 class="oui-tile__title" data-i18n-static="emailpro_tab_INFORMATIONS_stats"></h3>
                         <div class="oui-tile__body">
                             <ul class="list-unstyled">
                                 <li class="oui-tile__item">
                                     <div class="oui-tile__definition">
-                                        <strong class="d-block" data-i18n-static="exchange_dashboard_domains"></strong>
+                                        <strong class="d-block" data-i18n-static="emailpro_dashboard_domains"></strong>
                                         <span data-ng-bind="exchange.domainsNumber"></span>
                                     </div>
                                 </li>
@@ -93,7 +93,7 @@
                                 </li>
                                 <li class="oui-tile__item">
                                     <div class="oui-tile__definition">
-                                        <strong class="d-block" data-i18n-static="exchange_dashboard_tasks"></strong>
+                                        <strong class="d-block" data-i18n-static="emailpro_dashboard_tasks"></strong>
                                         <span data-ng-bind="exchange.tasksNumber"></span>
                                     </div>
                                 </li>
@@ -128,7 +128,7 @@
                                                     data-ng-if="displayOrderDiskSpace()"
                                                     data-ng-disabled="is25g();"
                                                     data-ng-click="orderDiskSpace()"
-                                                    data-i18n-static="exchange_action_order_space_disk">
+                                                    data-i18n-static="emailpro_action_order_space_disk">
                                             </button>
                                         </div>
                                     </div>
@@ -141,13 +141,13 @@
         </div>
         <div class="col-md-3">
             <div class="oui-tile mb-5">
-                <h3 class="oui-tile__title" data-i18n-static="exchange_tab_INFORMATIONS_connexion"></h3>
+                <h3 class="oui-tile__title" data-i18n-static="emailpro_tab_INFORMATIONS_connexion"></h3>
                 <div class="oui-tile__body">
                     <ul class="list-unstyled">
                         <li class="oui-tile__item">
                             <div class="oui-tile__definition">
-                                <strong class="d-block" data-i18n-static="exchange_tab_INFORMATIONS_webmail"></strong>
-                                <a data-ng-href="https://{{exchange.hostname}}" class="d-block word-break" target="_blank" title="{{ tr('exchange_dashboard_new_window') }}">
+                                <strong class="d-block" data-i18n-static="emailpro_tab_INFORMATIONS_webmail"></strong>
+                                <a data-ng-href="https://{{exchange.hostname}}" class="d-block word-break" target="_blank" title="{{ tr('emailpro_dashboard_new_window') }}">
                                     <span data-ng-bind="'https://' + exchange.hostname"></span>
                                     <span class="fa fa-external-link ml-2" aria-hidden="true"></span>
                                 </a>
@@ -155,9 +155,9 @@
                         </li>
                         <li class="oui-tile__item">
                             <div class="oui-tile__definition">
-                                <strong class="d-block" data-i18n-static="exchange_tab_INFORMATIONS_messaging"></strong>
-                                <a data-ng-href="{{ displayGuides }}" class="d-block word-break" target="_blank" title="{{tr('exchange_dashboard_guides_url')}} ({{tr('exchange_dashboard_new_window')}})">
-                                    <span data-i18n-static="exchange_dashboard_guides_url"></span>
+                                <strong class="d-block" data-i18n-static="emailpro_tab_INFORMATIONS_messaging"></strong>
+                                <a data-ng-href="{{ displayGuides }}" class="d-block word-break" target="_blank" title="{{tr('emailpro_dashboard_guides_url')}} ({{tr('emailpro_dashboard_new_window')}})">
+                                    <span data-i18n-static="emailpro_dashboard_guides_url"></span>
                                     <span class="fa fa-external-link ml-2" aria-hidden="true"></span>
                                 </a>
                             </div>
@@ -166,26 +166,26 @@
                 </div>
             </div>
             <div class="oui-tile mb-5" data-ng-if="sharepoint">
-                <h3 class="oui-tile__title" data-i18n-static="exchange_tab_INFORMATIONS_sharepoint"></h3>
+                <h3 class="oui-tile__title" data-i18n-static="emailpro_tab_INFORMATIONS_sharepoint"></h3>
                 <div class="oui-tile__body">
                     <ul class="list-unstyled">
                         <li class="oui-tile__item">
                             <div class="oui-tile__definition">
-                                <strong class="d-block" data-i18n-static="exchange_tab_INFORMATIONS_sharepoint_url"></strong>
+                                <strong class="d-block" data-i18n-static="emailpro_tab_INFORMATIONS_sharepoint_url"></strong>
                                 <a class="d-block word-break" target="_blank"
                                    data-ng-href="https://{{sharepoint.url}}"
                                    data-ng-hide="sharepoint.state === 'creating'">
                                     <span data-ng-bind="'https://' + sharepoint.url"></span>
                                     <span class="fa fa-external-link ml-2" aria-hidden="true"></span>
                                 </a>
-                                <span data-i18n-static="exchange_tab_INFORMATIONS_wait_activation"
+                                <span data-i18n-static="emailpro_tab_INFORMATIONS_wait_activation"
                                       data-ng-show="sharepoint.state === 'creating'"></span>
                             </div>
                         </li>
                         <li class="oui-tile__item">
                             <div class="oui-tile__definition">
                                 <a data-ng-href="#/configuration/sharepoint/{{exchange.domain}}/{{sharepoint.domain}}" class="d-block word-break">
-                                    <span data-i18n-static="exchange_tab_INFORMATIONS_service_url"></span>
+                                    <span data-i18n-static="emailpro_tab_INFORMATIONS_service_url"></span>
                                     <span class="fa fa-external-link ml-2" aria-hidden="true"></span>
                                 </a>
                             </div>
@@ -197,8 +197,8 @@
                 <span data-i18n-static="emailpro_dashboard_guides"></span>
                 <a data-ng-href="{{ displayGuides }}"
                    target="_blank"
-                   title="{{tr('exchange_dashboard_guides_url')}} ({{tr('exchange_dashboard_new_window')}})">
-                    <span data-i18n-static="exchange_dashboard_guides_url"></span>
+                   title="{{tr('emailpro_dashboard_guides_url')}} ({{tr('emailpro_dashboard_new_window')}})">
+                    <span data-i18n-static="emailpro_dashboard_guides_url"></span>
                     <span class="fa fa-external-link ml-2" aria-hidden="true"></span>
                 </a>
             </div>

--- a/src/emailpro/license/history/emailpro-license-history.js
+++ b/src/emailpro/license/history/emailpro-license-history.js
@@ -8,7 +8,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProLicenseHistory
   };
 
   const parseSerie = function (serie) {
-    _.set(serie, 'name', $scope.tr(`exchange_action_license_history_type_${serie.name}`));
+    _.set(serie, 'name', $scope.tr(`emailpro_action_license_history_type_${serie.name}`));
     const rawData = []; // data buffer
     angular.forEach(serie.data, (obj2) => {
       rawData.push(parseItem(obj2));
@@ -32,7 +32,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProLicenseHistory
       }, (failure) => {
         $scope.resetAction();
         $scope.loading = false;
-        $scope.setMessage($scope.tr('exchange_action_license_history_fail'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_action_license_history_fail'), failure.data);
       });
   };
 

--- a/src/emailpro/remove/emailpro-remove.html
+++ b/src/emailpro/remove/emailpro-remove.html
@@ -10,16 +10,16 @@
 
             <div data-ng-if="!exchange.renewType.deleteAtExpiration">
                 <p data-ng-bind-html="tr('emailpro_resilitation_action_intro', [exchange.displayName])"></p>
-                <p data-i18n-static="exchange_resilitation_action_hosted_warning"></p>
+                <p data-i18n-static="emailpro_resilitation_action_hosted_warning"></p>
             </div>
 
             <div data-ng-if="exchange.renewType.deleteAtExpiration">
                 <p data-ng-bind-html="tr('emailpro_resilitation_cancel_action_intro', [exchange.displayName])"></p>
 
-                <p class="mt-2" data-ng-bind-html="tr('exchange_update_billing_periode_intro')"></p>
+                <p class="mt-2" data-ng-bind-html="tr('emailpro_update_billing_periode_intro')"></p>
 
                 <form class="form-inline">
-                    <span class="mr-3" data-i18n-static="exchange_update_billing_periode_label"></span>
+                    <span class="mr-3" data-i18n-static="emailpro_update_billing_periode_label"></span>
 
                     <div class="oui-radio oui-radio_inline">
                         <input class="oui-radio__input"
@@ -29,8 +29,8 @@
                                data-ng-model="exchange.renewPeriod"
                                data-ng-value="'MONTHLY'">
                         <label class="oui-radio__label-container" for="MONTHLY">
-                            <span class="oui-radio__label" 
-                                  data-ng-bind="tr('exchange_ACTION_order_accounts_step2_pay_type_monthly')"></span>
+                            <span class="oui-radio__label"
+                                  data-ng-bind="tr('emailpro_ACTION_order_accounts_step2_pay_type_monthly')"></span>
                         </label>
                     </div>
 
@@ -42,8 +42,8 @@
                                data-ng-model="exchange.renewPeriod"
                                data-ng-value="'YEARLY'">
                         <label class="oui-radio__label-container" for="YEARLY">
-                            <span class="oui-radio__label" 
-                                  data-ng-bind="tr('exchange_ACTION_order_accounts_step2_pay_type_yearly')"></span>
+                            <span class="oui-radio__label"
+                                  data-ng-bind="tr('emailpro_ACTION_order_accounts_step2_pay_type_yearly')"></span>
                         </label>
                     </div>
                 </form>
@@ -56,10 +56,10 @@
                 <p data-ng-if="!exchange.deleteAtExpiration"
                    data-ng-bind-html="tr('emailpro_resilitation_action_confirmation', [exchange.displayName, exchange.accountsNumber])"></p>
                 <p data-ng-if="exchange.deleteAtExpiration"
-                   data-ng-bind-html="tr('exchange_resilitation_cancel_action_confirmation', [exchange.displayName, exchange.accountsNumber])"></p>
+                   data-ng-bind-html="tr('emailpro_resilitation_cancel_action_confirmation', [exchange.displayName, exchange.accountsNumber])"></p>
             </div>
 
-            <p data-ng-bind-html="tr('exchange_resilitation_cancel_action_confirmation', [exchange.displayName])"
+            <p data-ng-bind-html="tr('emailpro_resilitation_cancel_action_confirmation', [exchange.displayName])"
                data-ng-if="exchange.renewType.deleteAtExpiration"></p>
         </div>
     </div>

--- a/src/emailpro/service/configure/emailpro-service-configure.html
+++ b/src/emailpro/service/configure/emailpro-service-configure.html
@@ -9,11 +9,11 @@
             data-wizard-step-valid="formIsValid.value == true">
 
             <div data-ng-if="loaders.details == true && loaders.put == false"
-                 data-i18n-static="exchange_ACTION_loading">
+                 data-i18n-static="emailpro_ACTION_loading">
                 <oui-spinner data-size="s"></oui-spinner>
             </div>
             <div data-ng-if="loaders.details == false && loaders.put == true"
-                 data-i18n-static="exchange_ACTION_sending">
+                 data-i18n-static="emailpro_ACTION_sending">
                 <oui-spinner data-size="s"></oui-spinner>
             </div>
             <form name="serviceForm"
@@ -26,8 +26,8 @@
                         'has-error': serviceForm.lockoutThreshold.$invalid && serviceForm.lockoutThreshold.$dirty
                      }">
                     <label for="lockoutThreshold" class="control-label"
-                           data-i18n-static="exchange_ACTION_configure_services_label_lockoutThreshold"
-                           data-uib-tooltip="{{i18n['exchange_ACTION_configure_services_help_lockoutThreshold']}}"
+                           data-i18n-static="emailpro_ACTION_configure_services_label_lockoutThreshold"
+                           data-uib-tooltip="{{i18n['emailpro_ACTION_configure_services_help_lockoutThreshold']}}"
                            data-tooltip-placement="right">
                     </label>
                     <input type="number" class="form-control" id="lockoutThreshold" name="lockoutThreshold" min="0" max="14" required
@@ -50,11 +50,11 @@
                      }"
                      data-ng-if="service.lockoutThreshold !== 0 && service.lockoutThreshold != null">
                     <label for="lockoutObservationWindow" class="control-label"
-                           data-i18n-static="exchange_ACTION_configure_services_label_lockoutObservationWindow"></label>
+                           data-i18n-static="emailpro_ACTION_configure_services_label_lockoutObservationWindow"></label>
                     <input type="number" class="form-control" id="lockoutObservationWindow" name="lockoutObservationWindow" min="1" max="90"
                            data-ng-change="check(serviceForm.lockoutObservationWindow)"
                            data-ng-model="service.lockoutObservationWindow"
-                           data-uib-tooltip="{{i18n.exchange_ACTION_configure_services_tooltip_minutes}}"
+                           data-uib-tooltip="{{i18n.emailpro_ACTION_configure_services_tooltip_minutes}}"
                            data-ng-pattern="/^\d+$/"
                            data-ng-disabled="service.lockoutThreshold === 0"
                            data-ng-required="service.lockoutThreshold !== 0">
@@ -71,11 +71,11 @@
                      }"
                      data-ng-if="service.lockoutThreshold !== 0 && service.lockoutThreshold != null">
                     <label for="lockoutDuration" class="control-label"
-                           data-i18n-static="exchange_ACTION_configure_services_label_lockoutDuration"></label>
+                           data-i18n-static="emailpro_ACTION_configure_services_label_lockoutDuration"></label>
                     <input type="number" class="form-control" id="lockoutDuration" name="lockoutDuration" min="{{service.lockoutObservationWindow}}" max="90"
                            data-ng-change="check(serviceForm.lockoutDuration)"
                            data-ng-model="service.lockoutDuration"
-                           data-uib-tooltip="{{i18n.exchange_ACTION_configure_services_tooltip_minutes}}"
+                           data-uib-tooltip="{{i18n.emailpro_ACTION_configure_services_tooltip_minutes}}"
                            data-ng-pattern="/^\d+$/"
                            data-ng-disabled="service.lockoutThreshold === 0"
                            data-ng-required="service.lockoutThreshold !== 0">
@@ -88,7 +88,7 @@
                 <!-- Complexity Enabled -->
                 <oui-checkbox id="complexityEnabled" name="complexityEnabled"
                     data-model="service.complexityEnabled"
-                    data-text="{{::i18n.exchange_ACTION_configure_services_label_complexityEnabled}}">
+                    data-text="{{::i18n.emailpro_ACTION_configure_services_label_complexityEnabled}}">
                 </oui-checkbox>
                 <!-- Min password Age -->
                 <div class="form-group"
@@ -96,13 +96,13 @@
                         'has-error': serviceForm.minPasswordAge.$invalid && serviceForm.minPasswordAge.$dirty
                      }">
                     <label for="minPasswordAge" class="control-label"
-                           data-i18n-static="exchange_ACTION_configure_services_label_minPasswordAge"
-                           data-uib-tooltip="{{i18n['exchange_ACTION_configure_services_help_minPasswordAge']}}"
+                           data-i18n-static="emailpro_ACTION_configure_services_label_minPasswordAge"
+                           data-uib-tooltip="{{i18n['emailpro_ACTION_configure_services_help_minPasswordAge']}}"
                            data-tooltip-placement="right">
                     </label>
                     <input type="number" class="form-control" id="minPasswordAge" name="minPasswordAge" min="0" max="90" required
                            data-ng-change="checkPasswordAge()"
-                           data-uib-tooltip="{{i18n.exchange_ACTION_configure_services_tooltip_days}}"
+                           data-uib-tooltip="{{i18n.emailpro_ACTION_configure_services_tooltip_days}}"
                            data-ng-pattern="/^\d+$/"
                            data-ng-model="service.minPasswordAge">
                     <span class="help-block"
@@ -120,14 +120,14 @@
                         'has-error': serviceForm.maxPasswordAge.$invalid && serviceForm.maxPasswordAge.$dirty
                      }">
                     <label for="maxPasswordAge" class="control-label"
-                           data-i18n-static="exchange_ACTION_configure_services_label_maxPasswordAge"
-                           data-uib-tooltip="{{i18n['exchange_ACTION_configure_services_help_maxPasswordAge']}}"
+                           data-i18n-static="emailpro_ACTION_configure_services_label_maxPasswordAge"
+                           data-uib-tooltip="{{i18n['emailpro_ACTION_configure_services_help_maxPasswordAge']}}"
                            data-tooltip-placement="right">
                     </label>
                     <input type="number" class="form-control" id="maxPasswordAge" name="maxPasswordAge" min="0" max="90" required
                            data-ng-change="checkPasswordAge()"
                            data-ng-model="service.maxPasswordAge"
-                           data-uib-tooltip="{{i18n.exchange_ACTION_configure_services_tooltip_days}}"
+                           data-uib-tooltip="{{i18n.emailpro_ACTION_configure_services_tooltip_days}}"
                            data-ng-pattern="/^\d+$/">
                     <span class="help-block"
                           data-ng-if="service.maxPasswordAge == 0"
@@ -144,8 +144,8 @@
                         'has-error': serviceForm.minPasswordLength.$invalid && serviceForm.minPasswordLength.$dirty
                      }">
                     <label for="minPasswordLength" class="control-label"
-                           data-i18n-static="exchange_ACTION_configure_services_label_minPasswordLength"
-                           data-uib-tooltip="{{i18n['exchange_ACTION_configure_services_help_minPasswordLength']}}"
+                           data-i18n-static="emailpro_ACTION_configure_services_label_minPasswordLength"
+                           data-uib-tooltip="{{i18n['emailpro_ACTION_configure_services_help_minPasswordLength']}}"
                            data-tooltip-placement="right"></label>
                     <input type="number" class="form-control" id="minPasswordLength" name="minPasswordLength" min="0" max="14" required
                            data-ng-change="check(serviceForm.minPasswordLength)"
@@ -163,27 +163,27 @@
             </form>
             <div data-wizard-step-help>
                 <h3 data-i18n-static="emailpro_ACTION_configure_help_title"></h3>
-                <h4 data-i18n-static="exchange_ACTION_configure_help_lockoutThreshold_title"></h4>
-                <p data-ng-bind-html="tr('exchange_ACTION_configure_help_lockoutThreshold_text')"></p>
-                <h4 data-i18n-static="exchange_ACTION_configure_help_lockoutObservationWindow_title"></h4>
-                <p data-ng-bind-html="tr('exchange_ACTION_configure_help_lockoutObservationWindow_text')"></p>
-                <h4 data-i18n-static="exchange_ACTION_configure_help_lockoutDuration_title"></h4>
-                <p data-ng-bind-html="tr('exchange_ACTION_configure_help_lockoutDuration_text')"></p>
-                <h4 data-i18n-static="exchange_ACTION_configure_help_complexityEnabled_title"></h4>
-                <p data-ng-bind-html="tr('exchange_ACTION_configure_help_complexityEnabled_text')"></p>
-                <h4 data-i18n-static="exchange_ACTION_configure_help_minPasswordAge_title"></h4>
-                <p data-ng-bind-html="tr('exchange_ACTION_configure_help_minPasswordAge_text')"></p>
-                <h4 data-i18n-static="exchange_ACTION_configure_help_maxPasswordAge_title"></h4>
-                <p data-ng-bind-html="tr('exchange_ACTION_configure_help_maxPasswordAge_text')"></p>
-                <h4 data-i18n-static="exchange_ACTION_configure_help_minPasswordLength_title"></h4>
-                <p data-ng-bind-html="tr('exchange_ACTION_configure_help_minPasswordLength_text')"></p>
+                <h4 data-i18n-static="emailpro_ACTION_configure_help_lockoutThreshold_title"></h4>
+                <p data-ng-bind-html="tr('emailpro_ACTION_configure_help_lockoutThreshold_text')"></p>
+                <h4 data-i18n-static="emailpro_ACTION_configure_help_lockoutObservationWindow_title"></h4>
+                <p data-ng-bind-html="tr('emailpro_ACTION_configure_help_lockoutObservationWindow_text')"></p>
+                <h4 data-i18n-static="emailpro_ACTION_configure_help_lockoutDuration_title"></h4>
+                <p data-ng-bind-html="tr('emailpro_ACTION_configure_help_lockoutDuration_text')"></p>
+                <h4 data-i18n-static="emailpro_ACTION_configure_help_complexityEnabled_title"></h4>
+                <p data-ng-bind-html="tr('emailpro_ACTION_configure_help_complexityEnabled_text')"></p>
+                <h4 data-i18n-static="emailpro_ACTION_configure_help_minPasswordAge_title"></h4>
+                <p data-ng-bind-html="tr('emailpro_ACTION_configure_help_minPasswordAge_text')"></p>
+                <h4 data-i18n-static="emailpro_ACTION_configure_help_maxPasswordAge_title"></h4>
+                <p data-ng-bind-html="tr('emailpro_ACTION_configure_help_maxPasswordAge_text')"></p>
+                <h4 data-i18n-static="emailpro_ACTION_configure_help_minPasswordLength_title"></h4>
+                <p data-ng-bind-html="tr('emailpro_ACTION_configure_help_minPasswordLength_text')"></p>
              </div>
         </div>
 
         <div data-wizard-step>
             <strong data-ng-bind="tr('emailpro_ACTION_configure_step2_intro', [service.displayName])"></strong>
             <dl class="mt-5">
-                <dt data-i18n-static="exchange_ACTION_configure_step2_label_lockoutThreshold"></dt>
+                <dt data-i18n-static="emailpro_ACTION_configure_step2_label_lockoutThreshold"></dt>
                 <dd>
                     <span data-ng-if="service.lockoutThreshold == 0" data-i18n-static="lockoutThreshold_unit_value_0"></span>
                     <span data-ng-if="service.lockoutThreshold == 1" data-i18n-static="lockoutThreshold_unit_value_1"></span>
@@ -191,38 +191,38 @@
                 </dd>
 
                 <dt data-ng-if="service.lockoutThreshold !== 0 && service.lockoutObservationWindow !== 0"
-                    data-i18n-static="exchange_ACTION_configure_step2_label_lockoutObservationWindow"></dt>
+                    data-i18n-static="emailpro_ACTION_configure_step2_label_lockoutObservationWindow"></dt>
                 <dd data-ng-if="service.lockoutThreshold !== 0 && service.lockoutObservationWindow !== 0">
                     <span data-ng-if="service.lockoutObservationWindow == 1" data-i18n-static="lockoutObservationWindow_unit_value_1"></span>
                     <span data-ng-if="service.lockoutObservationWindow > 1" data-ng-bind="tr('lockoutObservationWindow_unit_value_many', [service.lockoutObservationWindow])"></span>
                 </dd>
 
                 <dt data-ng-if="service.lockoutThreshold !== 0"
-                    data-i18n-static="exchange_ACTION_configure_step2_label_lockoutDuration"></dt>
+                    data-i18n-static="emailpro_ACTION_configure_step2_label_lockoutDuration"></dt>
                 <dd data-ng-if="service.lockoutThreshold !== 0">
                     <span data-ng-if="service.lockoutDuration == 0" data-i18n-static="lockoutDuration_unit_value_0"></span>
                     <span data-ng-if="service.lockoutDuration == 1" data-i18n-static="lockoutDuration_unit_value_1"></span>
                     <span data-ng-if="service.lockoutDuration > 1" data-ng-bind="tr('lockoutDuration_unit_value_many', [service.lockoutDuration])"></span>
                 </dd>
 
-                <dt data-i18n-static="exchange_ACTION_configure_step2_label_complexityEnabled"></dt>
+                <dt data-i18n-static="emailpro_ACTION_configure_step2_label_complexityEnabled"></dt>
                 <dd data-ng-bind="tr('complexityEnabled_value_' + service.complexityEnabled)"></dd>
 
-                <dt data-i18n-static="exchange_ACTION_configure_step2_label_minPasswordAge"></dt>
+                <dt data-i18n-static="emailpro_ACTION_configure_step2_label_minPasswordAge"></dt>
                 <dd>
                     <span data-ng-if="service.minPasswordAge == 0" data-i18n-static="minPasswordAge_unit_value_0"></span>
                     <span data-ng-if="service.minPasswordAge == 1" data-i18n-static="minPasswordAge_unit_value_1"></span>
                     <span data-ng-if="service.minPasswordAge > 1" data-ng-bind="tr('minPasswordAge_unit_value_many', [service.minPasswordAge])"></span>
                 </dd>
 
-                <dt data-i18n-static="exchange_ACTION_configure_step2_label_maxPasswordAge"></dt>
+                <dt data-i18n-static="emailpro_ACTION_configure_step2_label_maxPasswordAge"></dt>
                 <dd>
                     <span data-ng-if="service.maxPasswordAge == 0" data-i18n-static="maxPasswordAge_unit_value_0"></span>
                     <span data-ng-if="service.maxPasswordAge == 1" data-i18n-static="maxPasswordAge_unit_value_1"></span>
                     <span data-ng-if="service.maxPasswordAge > 1" data-ng-bind="tr('maxPasswordAge_unit_value_many', [service.maxPasswordAge])"></span>
                 </dd>
 
-                <dt data-i18n-static="exchange_ACTION_configure_step2_label_minPasswordLength"></dt>
+                <dt data-i18n-static="emailpro_ACTION_configure_step2_label_minPasswordLength"></dt>
                 <dd>
                     <span data-ng-if="service.minPasswordLength == 0" data-i18n-static="minPasswordLength_unit_value_0"></span>
                     <span data-ng-if="service.minPasswordLength == 1" data-i18n-static="minPasswordLength_unit_value_1"></span>

--- a/src/emailpro/service/configure/emailpro-service-configure.js
+++ b/src/emailpro/service/configure/emailpro-service-configure.js
@@ -60,12 +60,12 @@ angular.module('App').controller('EmailProServicesConfigureCtrl', ['$scope', 'Ap
       $scope.resetAction();
       EmailPro.resetAccounts();
       $scope.loaders.put = false;
-      $scope.setMessage(Translator.tr('exchange_ACTION_configure_success'), { status: 'success' });
+      $scope.setMessage(Translator.tr('emailpro_ACTION_configure_success'), { status: 'success' });
     }, (reason) => {
       $scope.resetAction();
       $scope.loaders.put = false;
       _.assign(reason.data, { type: 'ERROR' });
-      $scope.setMessage(Translator.tr('exchange_ACTION_configure_error'), reason.data);
+      $scope.setMessage(Translator.tr('emailpro_ACTION_configure_error'), reason.data);
     });
   };
 

--- a/src/emailpro/task/emailpro-task.controller.js
+++ b/src/emailpro/task/emailpro-task.controller.js
@@ -18,7 +18,7 @@ angular.module('Module.emailpro.controllers')
             },
           };
         }).catch((failure) => {
-          $scope.setMessage($scope.tr('exchange_tab_TASKS_error_message'), failure.data);
+          $scope.setMessage($scope.tr('emailpro_tab_TASKS_error_message'), failure.data);
         });
     };
 

--- a/src/emailpro/task/emailpro-task.html
+++ b/src/emailpro/task/emailpro-task.html
@@ -2,33 +2,33 @@
 
     <div class="alert alert-warning" role="alert"
          data-ng-if="tasksList && tasksList.list.messages.length > 0"
-         data-i18n-static="exchange_tab_TASKS_partial">
+         data-i18n-static="emailpro_tab_TASKS_partial">
     </div>
 
     <oui-datagrid data-rows-loader="loadPaginated($config)">
-        <oui-column data-title="tr('exchange_tab_TASKS_table_function')" data-property="function">
-            <span data-ng-bind-html="tr('exchange_tab_TASKS_'+ $row.function)"></span>
+        <oui-column data-title="tr('emailpro_tab_TASKS_table_function')" data-property="function">
+            <span data-ng-bind-html="tr('emailpro_tab_TASKS_'+ $row.function)"></span>
         </oui-column>
-        <oui-column data-title="tr('exchange_tab_TASKS_table_state')" data-property="status">
+        <oui-column data-title="tr('emailpro_tab_TASKS_table_state')" data-property="status">
             <div data-ng-if="$row.status == stateDoing || $row.status == stateTodo">
                 <span class="fa fa-hourglass-half text-info" aria-hidden="true"></span>
-                <span data-ng-bind-html="tr('exchange_tab_TASKS_'+ $row.status)"></span>
+                <span data-ng-bind-html="tr('emailpro_tab_TASKS_'+ $row.status)"></span>
             </div>
             <div data-ng-if="$row.status == stateError">
                 <span class="fa fa-times-circle text-danger" aria-hidden="true"></span>
-                <span data-ng-bind-html="tr('exchange_tab_TASKS_'+ $row.status)"></span>
+                <span data-ng-bind-html="tr('emailpro_tab_TASKS_'+ $row.status)"></span>
             </div>
             <div data-ng-if="$row.status == stateCancelled">
                 <span class="fa fa-ban text-muted" aria-hidden="true"></span>
-                <span data-ng-bind-html="tr('exchange_tab_TASKS_'+ $row.status)"></span>
+                <span data-ng-bind-html="tr('emailpro_tab_TASKS_'+ $row.status)"></span>
             </div>
             <span data-ng-if="$row.status == stateDone"
-                  data-ng-bind-html="tr('exchange_tab_TASKS_'+ $row.status)"></span>
+                  data-ng-bind-html="tr('emailpro_tab_TASKS_'+ $row.status)"></span>
         </oui-column>
-        <oui-column data-title="tr('exchange_tab_TASKS_table_start_date')" data-property="todoDate" data-sortable="desc">
+        <oui-column data-title="tr('emailpro_tab_TASKS_table_start_date')" data-property="todoDate" data-sortable="desc">
             <span data-ng-bind="::$row.todoDate | date:'short'"></span>
         </oui-column>
-        <oui-column data-title="tr('exchange_tab_TASKS_table_finish_date')" data-property="finishDate">
+        <oui-column data-title="tr('emailpro_tab_TASKS_table_finish_date')" data-property="finishDate">
             <span data-ng-bind="::$row.finishDate | date:'short'"></span>
         </oui-column>
     </oui-datagrid>

--- a/src/emailpro/update/renew/emailpro-update-renew.controller.js
+++ b/src/emailpro/update/renew/emailpro-update-renew.controller.js
@@ -105,7 +105,7 @@ angular.module('Module.emailpro.controllers').controller('EmailProUpdateRenewCtr
       }, (failure) => {
         $scope.loading = false;
         if (failure) {
-          $scope.setMessage($scope.tr('exchange_tab_ACCOUNTS_error_message'), failure.data);
+          $scope.setMessage($scope.tr('emailpro_tab_ACCOUNTS_error_message'), failure.data);
           $scope.resetAction();
         }
       });
@@ -168,14 +168,14 @@ angular.module('Module.emailpro.controllers').controller('EmailProUpdateRenewCtr
     EmailPro.updateRenew($stateParams.productId, $scope.buffer.changes)
       .then((data) => {
         const updateRenewMessages = {
-          OK: $scope.tr('exchange_update_billing_periode_success'),
-          PARTIAL: $scope.tr('exchange_update_billing_periode_partial'),
-          ERROR: $scope.tr('exchange_update_billing_periode_failure'),
+          OK: $scope.tr('emailpro_update_billing_periode_success'),
+          PARTIAL: $scope.tr('emailpro_update_billing_periode_partial'),
+          ERROR: $scope.tr('emailpro_update_billing_periode_failure'),
         };
         $scope.setMessage(updateRenewMessages, data);
         $scope.resetAction();
       }, (failure) => {
-        $scope.setMessage($scope.tr('exchange_update_billing_periode_failure'), failure.data);
+        $scope.setMessage($scope.tr('emailpro_update_billing_periode_failure'), failure.data);
         $scope.resetAction();
       });
   };

--- a/src/emailpro/update/renew/emailpro-update-renew.html
+++ b/src/emailpro/update/renew/emailpro-update-renew.html
@@ -3,18 +3,18 @@
          data-wizard-bread-crumb
          data-wizard-on-cancel="reset"
          data-wizard-on-finish="submit"
-         data-wizard-title="i18n.exchange_update_billing_action_title">
+         data-wizard-title="i18n.emailpro_update_billing_action_title">
 
         <div data-wizard-step
              data-wizard-step-valid="buffer.hasChanged">
 
-            <p data-ng-bind-html="tr('exchange_update_billing_periode_intro')"></p>
+            <p data-ng-bind-html="tr('emailpro_update_billing_periode_intro')"></p>
 
             <form class="my-3">
                 <div class="form-group">
                     <div class="input-group">
                         <input type="text" class="form-control"
-                               placeholder="{{i18n.exchange_tab_ACCOUNTS_table_email}}"
+                               placeholder="{{i18n.emailpro_tab_ACCOUNTS_table_email}}"
                                data-ng-disabled="loading"
                                data-ng-model-options="{debounce: 1000}"
                                data-ng-model="search.value">
@@ -34,14 +34,14 @@
 
             <div class="alert alert-warning" role="alert"
                  data-ng-if="bufferedAccounts && bufferedAccounts.list.messages.length > 0 && !loading"
-                 data-i18n-static="exchange_tab_ACCOUNTS_partial">
+                 data-i18n-static="emailpro_tab_ACCOUNTS_partial">
             </div>
 
             <table class="table table-bordered">
                 <thead>
                     <tr>
-                        <th scope="col" data-i18n-static="exchange_tab_ACCOUNTS_table_email"></th>
-                        <th scope="col" data-i18n-static="exchange_update_billing_expiration_date_label"></th>
+                        <th scope="col" data-i18n-static="emailpro_tab_ACCOUNTS_table_email"></th>
+                        <th scope="col" data-i18n-static="emailpro_update_billing_expiration_date_label"></th>
                         <th scope="col" id="monthlyStateHeader"
                             data-ng-hide="account.partial || exchange.offer === 'PROVIDER' && !is25g()">
                             <label class="m-0">
@@ -51,7 +51,7 @@
                                        data-tsc-ids-all="buffer.ids"
                                        data-tsc-ids-selected="buffer.selectedMonthly"
                                        data-tsc-on-click="checkboxStateChange(state, 'MONTHLY')">
-                                <span data-i18n-static="exchange_update_billing_header_1M"></span>
+                                <span data-i18n-static="emailpro_update_billing_header_1M"></span>
                             </label>
                         </th>
                         <th scope="col" id="yearlyStateHeader">
@@ -61,7 +61,7 @@
                                        data-tsc-ids-all="buffer.ids"
                                        data-tsc-ids-selected="buffer.selectedYearly"
                                        data-tsc-on-click="checkboxStateChange(state, 'YEARLY')">
-                                <span data-i18n-static="exchange_update_billing_header_1Y"></span>
+                                <span data-i18n-static="emailpro_update_billing_header_1Y"></span>
                             </label>
                         </th>
                         <th scope="col" id="noneStateHeader">
@@ -71,7 +71,7 @@
                                        data-tsc-ids-all="buffer.ids"
                                        data-tsc-ids-selected="buffer.selectedDelete"
                                        data-tsc-on-click="checkboxStateChange(state, 'DELETE_AT_EXPIRATION')">
-                                <span data-i18n-static="exchange_update_billing_header_terminate"></span>
+                                <span data-i18n-static="emailpro_update_billing_header_terminate"></span>
                             </label>
                         </th>
                     </tr>
@@ -86,8 +86,8 @@
                 <tbody data-ng-if="bufferedAccounts.list.results.length === 0 && bufferedAccounts.list.messages.length === 0 && !loading">
                     <tr>
                         <td colspan="5">
-                            <span data-i18n-static="exchange_tab_ACCOUNTS_table_empty" data-ng-if="!search.value"></span>
-                            <span data-i18n-static="exchange_tab_ACCOUNTS_table_empty_search" data-ng-if="search.value"></span>
+                            <span data-i18n-static="emailpro_tab_ACCOUNTS_table_empty" data-ng-if="!search.value"></span>
+                            <span data-i18n-static="emailpro_tab_ACCOUNTS_table_empty_search" data-ng-if="search.value"></span>
                         </td>
                     </tr>
                 </tbody>
@@ -102,20 +102,20 @@
 
                         <td class="text-center"
                             data-ng-hide="account.partial || exchange.offer === 'PROVIDER' && !is25g()">
-                            <input type="radio" title="{{i18n.exchange_update_billing_header_1M}}" aria-labelledby="monthlyStateHeader primaryEmailDisplayName{{$index}}"
+                            <input type="radio" title="{{i18n.emailpro_update_billing_header_1M}}" aria-labelledby="monthlyStateHeader primaryEmailDisplayName{{$index}}"
                                    data-ng-change="trackSelected(account.primaryEmailAddress, account.renewPeriod);"
                                    data-ng-model="account.renewPeriod"
                                    data-ng-value="'MONTHLY'">
                         </td>
                         <td class="text-center"
                             data-ng-hide="account.partial">
-                            <input type="radio" title="{{i18n.exchange_update_billing_header_1Y}}" aria-labelledby="yearlyStateHeader primaryEmailDisplayName{{$index}}"
+                            <input type="radio" title="{{i18n.emailpro_update_billing_header_1Y}}" aria-labelledby="yearlyStateHeader primaryEmailDisplayName{{$index}}"
                                    data-ng-change="trackSelected(account.primaryEmailAddress, account.renewPeriod);"
                                    data-ng-model="account.renewPeriod"
                                    data-ng-value="'YEARLY'">
                         </td>
                         <td class="text-center">
-                            <input type="radio" title="{{i18n.exchange_update_billing_header_terminate}}" aria-labelledby="noneStateHeader primaryEmailDisplayName{{$index}}"
+                            <input type="radio" title="{{i18n.emailpro_update_billing_header_terminate}}" aria-labelledby="noneStateHeader primaryEmailDisplayName{{$index}}"
                                    data-ng-change="trackSelected(account.primaryEmailAddress, account.renewPeriod);"
                                    data-ng-model="account.renewPeriod"
                                    data-ng-value="'DELETE_AT_EXPIRATION'">
@@ -126,7 +126,7 @@
                         <td colspan="5">
                             <span class="fa fa-exclamation-triangle mr-2" aria-hidden="true"></span>
                             <span data-ng-bind="account.id"
-                                  data-uib-tooltip="{{i18n.exchange_tab_ACCOUNTS_partial_account}}"></span>
+                                  data-uib-tooltip="{{i18n.emailpro_tab_ACCOUNTS_partial_account}}"></span>
                         </td>
                     </tr>
                 </tbody>
@@ -141,18 +141,18 @@
             <div class="alert alert-warning"
                  role="alert"
                  data-ng-if="(exchange.offer === 'HOSTED' || exchange.offer === 'PROVIDER') && exchange.serverDiagnostic.version === 15 && !account.partial"
-                 data-i18n-static="exchange_update_billing_periode_delete_warning">
+                 data-i18n-static="emailpro_update_billing_periode_delete_warning">
             </div>
         </div>
 
         <div data-wizard-step>
-            <strong data-i18n-static="exchange_update_billing_periode_resume"></strong>
+            <strong data-i18n-static="emailpro_update_billing_periode_resume"></strong>
 
             <table class="table table-bordered my-3">
                 <thead>
                     <tr>
-                        <th scope="col" data-i18n-static="exchange_tab_ACCOUNTS_table_email"></th>
-                        <th scope="col" class="text-center" data-i18n-static="exchange_update_billing_header_new_periode" style="width: 150px;"></th>
+                        <th scope="col" data-i18n-static="emailpro_tab_ACCOUNTS_table_email"></th>
+                        <th scope="col" class="text-center" data-i18n-static="emailpro_update_billing_header_new_periode" style="width: 150px;"></th>
                     </tr>
                 </thead>
 
@@ -162,7 +162,7 @@
                         <th scope="row" data-ng-bind="account.primaryEmailDisplayName"></th>
 
                         <td class="text-center"
-                            data-ng-bind="tr('exchange_update_billing_periode_value_'+ [account.renewPeriod])"></td>
+                            data-ng-bind="tr('emailpro_update_billing_periode_value_'+ [account.renewPeriod])"></td>
                     </tr>
                 </tbody>
             </table>
@@ -170,7 +170,7 @@
             <div class="alert alert-warning"
                  role="alert"
                  data-ng-if="displayDeleteWarning"
-                 data-i18n-static="exchange_update_billing_periode_delete_warning">
+                 data-i18n-static="emailpro_update_billing_periode_delete_warning">
             </div>
         </div>
     </div>

--- a/src/resources/i18n/emailpro/Messages_fr_FR.xml
+++ b/src/resources/i18n/emailpro/Messages_fr_FR.xml
@@ -119,4 +119,575 @@
    <translation id="emailpro_ACTION_order_accounts_step1_price_with_tax_only" qtlid="499930">{0} ({0} TTC)</translation>
    <translation id="emailpro_ACTION_order_accounts_step1_user_error" qtlid="499943">Erreur lors de la récupération des informations de l'utilisateur</translation>
 
+
+   <translation id="emailpro_ACTION_add_account_button" qtlid="21487">Ajouter un compte</translation>
+   <translation id="emailpro_ACTION_add_account_legal_warning" qtlid="209099">Je reconnais qu'OVH procédera à l’exécution immédiate de la prestation à compter de la validation de ma commande et à ce titre je renonce expressément à exercer mon droit de rétractation conformément aux dispositions de l’article L.121-21-8 du code de la consommation.</translation>
+   <translation id="emailpro_ACTION_add_account_option_fail" qtlid="144045">Une erreur est survenue lors du chargement de vos domaines.</translation>
+   <translation id="emailpro_ACTION_add_account_step1_display_name_label" qtlid="23515">Nom à afficher</translation>
+   <translation id="emailpro_ACTION_add_account_step1_email_label" qtlid="137244">Compte e-mail</translation>
+   <translation id="emailpro_ACTION_add_account_step1_first_name_label" qtlid="23323">Prénom</translation>
+   <translation id="emailpro_ACTION_add_account_step1_last_name_label" qtlid="3818">Nom</translation>
+   <translation id="emailpro_ACTION_add_account_step2_confirmation_intro" qtlid="136841">Votre compte :</translation>
+   <translation id="emailpro_ACTION_add_account_step2_display_name_label" qtlid="23515">Nom à afficher</translation>
+   <translation id="emailpro_ACTION_add_account_step2_email_label" qtlid="137244">Compte e-mail</translation>
+   <translation id="emailpro_ACTION_add_account_step2_first_name_label" qtlid="23323">Prénom</translation>
+   <translation id="emailpro_ACTION_add_account_step2_last_name_label" qtlid="3818">Nom</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_content" qtlid="152271">Contenu</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_error_message" qtlid="152375">Une erreur est survenue lors de la création de la signature .</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_helpwizard_title" qtlid="152531">La signature</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_no_domains" qtlid="155274">Vous ne pouvez créer qu'une signature par domaine validé. Actuellement tous vos domaines valides ont déjà une signature.</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_City" qtlid="33310">Ville</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_Company" qtlid="49022">Entreprise</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_Country" qtlid="25171">Pays</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_Department" qtlid="30706">Département</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_DisplayName" qtlid="80922">Nom affiché</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_Email" qtlid="69509">E-mail</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_FaxNumber" qtlid="152388">Numéro de fax</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_FirstName" qtlid="23323">Prénom</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_HomePhoneNumber" qtlid="152401">Numéro de téléphone du domicile</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_Initials" qtlid="152414">Initiales</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_LastName" qtlid="3818">Nom</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_Manager" qtlid="152427">Responsable</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_MobileNumber" qtlid="152440">Numéro de mobile</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_Name" qtlid="109614">Nom complet</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_Notes" qtlid="69389">Notes</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_Office" qtlid="59555">Bureau</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_OtherFaxNumber" qtlid="152453">Fax 2</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_OtherHomePhoneNumber" qtlid="152466">Domicile 2</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_OtherPhoneNumber" qtlid="152479">Téléphone 2</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_PagerNumber" qtlid="152492">Numéro de pager</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_PhoneNumber" qtlid="152505">Numéro de téléphone</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_State" qtlid="32434">Région</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_Street" qtlid="152518">Rue</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_Title" qtlid="16469">Titre</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_UserLogonName" qtlid="46792">Identifiant</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_option_ZipCode" qtlid="30346">Code postal</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_outside" qtlid="152349">Activer la signature uniquement pour les envois vers l'extérieur</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_success_message" qtlid="152362">La création de la signature va être effectuée.</translation>
+   <translation id="emailpro_ACTION_add_disclaimer_title" qtlid="152206">Ajouter une signature</translation>
+   <translation id="emailpro_ACTION_change_password_account_error_message_linked" qtlid="148279">Cependant, une erreur est survenue lors du changement de mot de passe.</translation>
+   <translation id="emailpro_ACTION_configure_error" qtlid="178276">Erreur lors de la requête, les modifications ne seront pas appliquées</translation>
+   <translation id="emailpro_ACTION_configure_help_complexityEnabled_text" qtlid="178692">Ce paramètre de sécurité détermine si les mots de passe doivent respecter des exigences de complexité.<br/>Si cette stratégie est activée, les mots de passe doivent respecter les exigences minimales suivantes : <ul><li>Ne pas contenir tout ou partie du nom du compte de l'utilisateur</li> <li>Avoir une longueur d'au moins 6 caractères</li> <li>Contenir des caractères de trois des quatre catégories suivantes : <ol><li>Caractères majuscules de l'alphabet anglais (A à Z)</li> <li>Caractères minuscules de l'alphabet anglais (a à z)</li> <li>Chiffres de la base 10 (0 à 9)</li> <li>Caractères non alphabétiques (par exemple, !, $, #, %)</li></ol></li> </ul>Les exigences de complexité sont appliquées quand les mots de passe sont modifiés ou créés.</translation>
+   <translation id="emailpro_ACTION_configure_help_complexityEnabled_title" qtlid="178003">Exigences de complexité</translation>
+   <translation id="emailpro_ACTION_configure_help_lockoutDuration_text" qtlid="178653">Ce paramètre de sécurité détermine le nombre de minutes durant lequel un compte reste verrouillé avant d'être déverrouillé automatiquement. La plage disponible s'étend de 1 à 90 minutes.<br/>Si le seuil de verrouillage d'un compte est défini, la durée de verrouillage des comptes doit être supérieure ou égale à la durée de réinitialisation.</translation>
+   <translation id="emailpro_ACTION_configure_help_lockoutDuration_title" qtlid="178640">Durée de verrouillage des comptes</translation>
+   <translation id="emailpro_ACTION_configure_help_lockoutObservationWindow_text" qtlid="178679">Ce paramètre de sécurité détermine le nombre de minutes qui doivent s'écouler après une tentative d'ouverture de session infructueuse pour que le compteur de tentatives d'ouverture de session infructueuses soit remis à zéro. La plage disponible s'étend de 1 minute à 90 minutes.<br/>Si le seuil de verrouillage d'un compte est défini, le délai avant réinitialisation doit être inférieur ou égal à la durée de verrouillage des comptes.</translation>
+   <translation id="emailpro_ACTION_configure_help_lockoutObservationWindow_title" qtlid="178666">Délai de réinitialisation du compteur de verrouillages</translation>
+   <translation id="emailpro_ACTION_configure_help_lockoutThreshold_text" qtlid="178627">Ce paramètre de sécurité détermine le nombre de tentatives d'ouverture de session infructueuses qui provoque le verrouillage d'un compte utilisateur. Un compte verrouillé ne peut pas être utilisé jusqu'à sa réinitialisation par un administrateur ou jusqu'à ce que la durée de verrouillage du compte soit expirée. Vous pouvez définir une valeur comprise entre 1 et 14 tentatives d'ouverture de session infructueuses. Si vous définissez la valeur sur 0, le compte ne se verrouille jamais.</translation>
+   <translation id="emailpro_ACTION_configure_help_lockoutThreshold_title" qtlid="177990">Seuil de verrouillage du compte</translation>
+   <translation id="emailpro_ACTION_configure_help_maxPasswordAge_text" qtlid="181578">Ce paramètre de sécurité détermine la période de temps (en jours) durant laquelle un mot de passe peut être utilisé avant que le système ne demande à l'utilisateur de le modifier. Vous pouvez définir ce paramètre pour que les mots de passe expirent après un nombre de jours compris entre 1 et 90 ou vous pouvez spécifier que les mots de passe ne doivent jamais expirer en définissant le nombre de jours sur la valeur 0. Si la durée de vie maximale du mot de passe est comprise entre 1 et 90 jours, la durée de vie minimale des mots de passe doit être inférieure à la durée de vie maximale de celui-ci. Si la durée de vie maximale du mot de passe est définie sur la valeur 0, la durée de vie minimale peut être définie sur n'importe quelle valeur comprise entre 0 et 90 jours.</translation>
+   <translation id="emailpro_ACTION_configure_help_maxPasswordAge_title" qtlid="178731">Durée de vie maximale des mots de passe</translation>
+   <translation id="emailpro_ACTION_configure_help_minPasswordAge_text" qtlid="178718">Ce paramètre détermine la période de temps (en jours) durant laquelle un mot de passe doit être utilisé avant que l'utilisateur puisse le modifier. Vous pouvez définir une valeur comprise entre 1 et 90 jours ou bien vous pouvez autoriser immédiatement des modifications en définissant ce nombre de jours sur la valeur 0.</translation>
+   <translation id="emailpro_ACTION_configure_help_minPasswordAge_title" qtlid="178705">Durée de vie minimale des mots de passe</translation>
+   <translation id="emailpro_ACTION_configure_help_minPasswordLength_text" qtlid="178757">Ce paramètre de sécurité détermine le nombre minimal de caractères que peut contenir un mot de passe pour un compte d'utilisateur. Vous pouvez définir une valeur comprise entre 3 et 14 caractères ou bien vous pouvez indiquer qu'un mot de passe n'est pas requis en définissant ce nombre de caractères à 0.</translation>
+   <translation id="emailpro_ACTION_configure_help_minPasswordLength_title" qtlid="174828">Longueur minimale du mot de passe</translation>
+   <translation id="emailpro_ACTION_configure_services_help_lockoutThreshold" qtlid="178549">Si vous entrez "0", le compte ne sera jamais bloqué.</translation>
+   <translation id="emailpro_ACTION_configure_services_help_maxPasswordAge" qtlid="178588">Si vous entrez "0", le mot de passe sera toujours valide.</translation>
+   <translation id="emailpro_ACTION_configure_services_help_minPasswordAge" qtlid="178575">Si vous entrez "0", vous autorisez immédiatement la modification du mot de passe.</translation>
+   <translation id="emailpro_ACTION_configure_services_help_minPasswordLength" qtlid="178601">Si vous entrez "0", aucun mot de passe n'est pas requis</translation>
+   <translation id="emailpro_ACTION_configure_services_label_complexityEnabled" qtlid="178003">Exigences de complexité</translation>
+   <translation id="emailpro_ACTION_configure_services_label_lockoutDuration" qtlid="179706">Durée de verrouillage</translation>
+   <translation id="emailpro_ACTION_configure_services_label_lockoutObservationWindow" qtlid="179719">Délai de réinitialisation</translation>
+   <translation id="emailpro_ACTION_configure_services_label_lockoutThreshold" qtlid="179732">Seuil de verrouillage</translation>
+   <translation id="emailpro_ACTION_configure_services_label_maxPasswordAge" qtlid="179745">Durée de vie maximale du mot de passe</translation>
+   <translation id="emailpro_ACTION_configure_services_label_minPasswordAge" qtlid="376089">Empêcher le changement du mot de passe</translation>
+   <translation id="emailpro_ACTION_configure_services_label_minPasswordLength" qtlid="174828">Longueur minimale du mot de passe</translation>
+   <translation id="emailpro_ACTION_configure_services_tooltip_days" qtlid="179771">Exprimé en jours</translation>
+   <translation id="emailpro_ACTION_configure_services_tooltip_minutes" qtlid="179784">Exprimé en minutes</translation>
+   <translation id="emailpro_ACTION_configure_step2_label_complexityEnabled" qtlid="178393">Exigences de complexité du mot de passe :</translation>
+   <translation id="emailpro_ACTION_configure_step2_label_lockoutDuration" qtlid="178302">Durée de verrouillage du compte :</translation>
+   <translation id="emailpro_ACTION_configure_step2_label_lockoutObservationWindow" qtlid="178341">Fenêtre d’observation pour le verrouillage des comptes :</translation>
+   <translation id="emailpro_ACTION_configure_step2_label_lockoutThreshold" qtlid="178328">Seuil de verrouillage du compte :</translation>
+   <translation id="emailpro_ACTION_configure_step2_label_maxPasswordAge" qtlid="178354">Durée de vie maximale du mot de passe :</translation>
+   <translation id="emailpro_ACTION_configure_step2_label_minPasswordAge" qtlid="178367">Empêcher le changement du mot de passe :</translation>
+   <translation id="emailpro_ACTION_configure_step2_label_minPasswordLength" qtlid="178380">Longueur minimale du mot de passe :</translation>
+   <translation id="emailpro_ACTION_configure_success" qtlid="176700">Les modifications seront prises en compte</translation>
+   <translation id="emailpro_ACTION_delegation_behalf_tooltip" qtlid="181513">Veuillez avant désactiver le droit d'envoi.</translation>
+   <translation id="emailpro_ACTION_delegation_doing_message" qtlid="144266">La mise à jour des droits de délégation va être effectuée.</translation>
+   <translation id="emailpro_ACTION_delegation_error_message" qtlid="144279">Une erreur est survenue lors de la mise à jour des droits de délégation.</translation>
+   <translation id="emailpro_ACTION_delegation_partial_message" qtlid="156758">Des erreurs est survenue lors de la mise à jour des droits de délégation.</translation>
+   <translation id="emailpro_ACTION_delegation_sendas_tooltip" qtlid="181539">Veuillez avant désactiver le droit d'envoyer de la part.</translation>
+   <translation id="emailpro_ACTION_delegation_step1_email_header" qtlid="137244">Compte e-mail</translation>
+   <translation id="emailpro_ACTION_delegation_step1_full_header" qtlid="181500">Droit d'accès</translation>
+   <translation id="emailpro_ACTION_delegation_step1_sendOnBehalfTo_header" qtlid="181487">Droit d'envoyer de la part</translation>
+   <translation id="emailpro_ACTION_delegation_step1_send_header" qtlid="181474">Droit d'envoi</translation>
+   <translation id="emailpro_ACTION_delegation_step1_task_on_doing" qtlid="201458">Tâche en cours</translation>
+   <translation id="emailpro_ACTION_delegation_step2_email_header" qtlid="137244">Compte e-mail</translation>
+   <translation id="emailpro_ACTION_delegation_step2_full_header" qtlid="144253">Droit d'accès</translation>
+   <translation id="emailpro_ACTION_delegation_step2_intro" qtlid="434564">Les droits de délégation afférents au compte <strong>{0}</strong> :</translation>
+   <translation id="emailpro_ACTION_delegation_step2_right_true" qtlid="34776">Oui</translation>
+   <translation id="emailpro_ACTION_delegation_step2_sendOnBehalfTo_header" qtlid="181487">Droit d'envoyer de la part</translation>
+   <translation id="emailpro_ACTION_delegation_step2_send_header" qtlid="143798">Droit d'envoi</translation>
+   <translation id="emailpro_ACTION_delegation_success_message" qtlid="144266">La mise à jour des droits de délégation va être effectuée.</translation>
+   <translation id="emailpro_ACTION_delegation_title" qtlid="143733">Configuration délégation</translation>
+   <translation id="emailpro_ACTION_delegation_wait_behalf_tooltip" qtlid="181526">Veuillez attendre que la désactivation des droits d'envoi soit effective.</translation>
+   <translation id="emailpro_ACTION_delegation_wait_sendas_tooltip" qtlid="181552">Veuillez attendre que la désactivation des droits d'envoyer de la part soit effective.</translation>
+   <translation id="emailpro_ACTION_delete_disclaimer_failure" qtlid="152583">Une erreur est survenue lors de la suppression de la signature .</translation>
+   <translation id="emailpro_ACTION_delete_disclaimer_success" qtlid="152570">La signature va être supprimée.</translation>
+   <translation id="emailpro_ACTION_delete_disclaimer_title" qtlid="152219">Supprimer une signature</translation>
+   <translation id="emailpro_ACTION_disclaimer_associated_domains" qtlid="133110">Domaine associé</translation>
+   <translation id="emailpro_ACTION_disclaimer_insert" qtlid="152336">Insérer une variable</translation>
+   <translation id="emailpro_ACTION_loading" qtlid="75954">Chargement en cours...</translation>
+   <translation id="emailpro_ACTION_order_accounts_button" qtlid="139169">Commander des comptes</translation>
+   <translation id="emailpro_ACTION_order_accounts_step1_loading_error" qtlid="135294">Une erreur est survenue lors du chargement des informations.</translation>
+   <translation id="emailpro_ACTION_order_accounts_step1_number" qtlid="139338">Nombre de comptes :</translation>
+   <translation id="emailpro_ACTION_order_accounts_step1_number_tooltip" qtlid="144110">Entrez un nombre entre 1 et 100</translation>
+   <translation id="emailpro_ACTION_order_accounts_step1_number_not_valid" qtlid="144123">Entrez un nombre valide</translation>
+   <translation id="emailpro_ACTION_order_accounts_step1_pay_type" qtlid="139325">Type de paiement :</translation>
+   <translation id="emailpro_ACTION_order_accounts_step1_pay_type_01" qtlid="79530">mensuel</translation>
+   <translation id="emailpro_ACTION_order_accounts_step1_pay_type_12" qtlid="79542">annuel</translation>
+   <translation id="emailpro_ACTION_order_accounts_step2_error_message" qtlid="139468">Une erreur est survenue lors de la commande.</translation>
+   <translation id="emailpro_ACTION_order_accounts_step2_intro" qtlid="139403">Resumé de votre commande</translation>
+   <translation id="emailpro_ACTION_order_accounts_step2_loader" qtlid="139377">Vérification des paramètres de la commande en cours</translation>
+   <translation id="emailpro_ACTION_order_accounts_step2_number" qtlid="139338">Nombre de comptes :</translation>
+   <translation id="emailpro_ACTION_order_accounts_step2_pay_type" qtlid="139325">Type de paiement :</translation>
+   <translation id="emailpro_ACTION_order_accounts_step2_pay_type_monthly" qtlid="79530">mensuel</translation>
+   <translation id="emailpro_ACTION_order_accounts_step2_pay_type_yearly" qtlid="79542">annuel</translation>
+   <translation id="emailpro_ACTION_order_accounts_step2_price" qtlid="139416">{0} HT ({1} TTC)</translation>
+   <translation id="emailpro_ACTION_order_accounts_step2_total" qtlid="139429">Total facturé :</translation>
+   <translation id="emailpro_ACTION_order_accounts_step3_bc" qtlid="169524">Le bon de commande a été généré avec succès.</translation>
+   <translation id="emailpro_ACTION_order_accounts_step3_continue" qtlid="169537">Afin de confirmer votre commande, veuillez cliquer sur le bouton "Régler" ci-dessous.</translation>
+   <translation id="emailpro_ACTION_order_accounts_step3_explication" qtlid="139481">Veuillez noter qu'un délai d'environ 10 minutes à compter de l'acceptation de votre paiement est nécessaire pour que le compte soit créé.</translation>
+   <translation id="emailpro_ACTION_order_accounts_step3_explication2" qtlid="144175">Un nouvel onglet s'ouvrira et vous serez automatiquement redirigé vers l'interface de paiement OVH.</translation>
+   <translation id="emailpro_ACTION_order_accounts_step3_generation_bc" qtlid="169511">Génération du bon de commande ...</translation>
+   <translation id="emailpro_ACTION_sending" qtlid="71009">Envoi en cours...</translation>
+   <translation id="emailpro_ACTION_update_account_error_message_linked" qtlid="157421">Cependant, une erreur est survenue lors de la configuration d'autres paramètres du compte.</translation>
+   <translation id="emailpro_ACTION_update_account_helpwizard_password_title" qtlid="2270">Mot de passe</translation>
+   <translation id="emailpro_ACTION_update_account_helpwizard_password" qtlid="171240">Les mots de passe doivent respecter les exigences minimales suivantes :<br/><br/>- Ne pas contenir tout ou partie du nom du compte de l'utilisateur<br/>- Avoir une longueur d'au moins {0} caractères<br/>- Contenir des caractères de trois des quatre catégories suivantes :<br/><ul><li>Caractères majuscules de l'alphabet (A à Z)<br/></li><li>Caractères minuscules de l'alphabet (a à z)<br/></li><li>Chiffres de la base 10 (0 à 9)<br/></li><li>Caractères non alphabétiques (par exemple: !, $, #, %)<br/></li></ul></translation>
+   <translation id="emailpro_ACTION_update_account_helpwizard_password_simple" qtlid="195139">Les mots de passe doivent avoir une longueur d'au moins {0} caractères</translation>
+   <translation id="emailpro_ACTION_update_account_step1_complex_password_tooltip" qtlid="178822">Minimum {0} caractères alphanumériques, chiffres et signes spéciaux.</translation>
+   <translation id="emailpro_ACTION_update_account_step1_display_name_label" qtlid="23515">Nom à afficher</translation>
+   <translation id="emailpro_ACTION_update_account_step1_first_name_label" qtlid="23323">Prénom</translation>
+   <translation id="emailpro_ACTION_update_account_step1_last_name_label" qtlid="3818">Nom</translation>
+   <translation id="emailpro_ACTION_update_account_step1_password_confirmation_label" qtlid="9983">Confirmation</translation>
+   <translation id="emailpro_ACTION_update_account_step1_password_contains_samaccount_name" qtlid="254869">Le mot de passe ne peut pas contenir "{0}", le samaccountName, un identifiant interne.</translation>
+   <translation id="emailpro_ACTION_update_account_step1_password_different" qtlid="139637">Mots de passe différents.</translation>
+   <translation id="emailpro_ACTION_update_account_step1_password_label" qtlid="2270">Mot de passe</translation>
+   <translation id="emailpro_ACTION_update_account_step1_password_placeholder" qtlid="156745">Garder l'ancien</translation>
+   <translation id="emailpro_ACTION_update_account_step1_password_weak" qtlid="139624">Mot de passe trop simple.</translation>
+   <translation id="emailpro_ACTION_update_account_step1_quota_label" qtlid="6874">Quota</translation>
+   <translation id="emailpro_ACTION_update_account_step1_simple_password_tooltip" qtlid="137595">Minimum {0} caractères.</translation>
+   <translation id="emailpro_ACTION_update_account_step1_type_label" qtlid="191057">Type compte</translation>
+   <translation id="emailpro_ACTION_update_account_step1_type_STANDARD" qtlid="48998">Standard</translation>
+   <translation id="emailpro_ACTION_update_account_step1_type_BASIC" qtlid="48986">Basic</translation>
+   <translation id="emailpro_ACTION_update_account_step1_type_ENTERPRISE" qtlid="49022">Entreprise</translation>
+   <translation id="emailpro_ACTION_update_account_step1_type_cant_change" qtlid="486243">Le type de compte ne peut être changé tant qu'une licence Outlook est associée à ce compte.</translation>
+   <translation id="emailpro_ACTION_update_account_step1_exchange_guid_label" qtlid="174633">Exchange GUID</translation>
+   <translation id="emailpro_ACTION_update_account_step2_confirmation_intro" qtlid="136841">Votre compte :</translation>
+   <translation id="emailpro_ACTION_update_account_step2_display_name_label" qtlid="23515">Nom à afficher</translation>
+   <translation id="emailpro_ACTION_update_account_step2_email_label" qtlid="137244">Compte e-mail</translation>
+   <translation id="emailpro_ACTION_update_account_step2_first_name_label" qtlid="23323">Prénom</translation>
+   <translation id="emailpro_ACTION_update_account_step2_last_name_label" qtlid="3818">Nom</translation>
+   <translation id="emailpro_ACTION_update_account_step2_password_label" qtlid="139650">Mot de passe</translation>
+   <translation id="emailpro_ACTION_update_disclaimer_error_message" qtlid="152635">Une erreur est survenue lors de la modification de la signature .</translation>
+   <translation id="emailpro_ACTION_update_disclaimer_info" qtlid="152609">Modifier la signature associée au domaine {0}</translation>
+   <translation id="emailpro_ACTION_update_disclaimer_length_warning" qtlid="152648">Le contenu de la signature ne doit pas dépasser 5000 caractères ou contenir d'image locale.</translation>
+   <translation id="emailpro_ACTION_update_disclaimer_success_message" qtlid="152622">La signature va être modifiée.</translation>
+   <translation id="emailpro_ACTION_update_disclaimer_title" qtlid="152596">Configurer une signature</translation>
+   <translation id="emailpro_GROUPS_delegation_doing_message" qtlid="144266">La mise à jour des droits de délégation va être effectuée.</translation>
+   <translation id="emailpro_GROUPS_delegation_error_message" qtlid="144279">Une erreur est survenue lors de la mise à jour des droits de délégation.</translation>
+   <translation id="emailpro_GROUPS_delegation_success_message" qtlid="144266">La mise à jour des droits de délégation va être effectuée.</translation>
+   <translation id="emailpro_GROUPS_partial_account" qtlid="191161">Une erreur est survenue lors du chargement : {0}</translation>
+
+   <translation id="emailpro_action_license_history_fail" qtlid="169641">Une erreur est survenue lors du chargement des informations de monitoring.</translation>
+   <translation id="emailpro_action_license_history_type_outlook" qtlid="193111">Licences Outlook</translation>
+   <translation id="emailpro_action_order_space_disk" qtlid="191668">Commander de l'espace additionnel</translation>
+
+   <translation id="emailpro_dashboard_2016_migration" qtlid="287072">Consulter le programme des migrations vers Exchange 2016.</translation>
+   <translation id="emailpro_dashboard_action_doing" qtlid="149787">Opération en cours...</translation>
+   <translation id="emailpro_dashboard_diag" qtlid="136230">Diagnostic serveur</translation>
+   <translation id="emailpro_dashboard_diag_a_label" qtlid="23803">A</translation>
+   <translation id="emailpro_dashboard_diag_a_tooltip_error" qtlid="209151">Si votre domaine est hébergé chez OVH, veuillez créer le champs A en sélectionnant le nom de domaine concerné, ensuite "Mode expert" -> "Zone DNS" -> "Ajouter une entrée". Saisissez : <br /> Type de champ : <span class="bold">A</span> <br /> Sous domaine : <span class="bold">{0}</span> <br /> Cible : <span class="bold">{1}</span> <br /><br /> Si votre domaine est hébergé ailleurs, alors créez le champ A sur ce domaine depuis le manager de votre fournisseur en donnant les mêmes informations que ci-dessus.</translation>
+   <translation id="emailpro_dashboard_diag_a_tooltip_ok" qtlid="137491">Configuration automatique effectuée</translation>
+   <translation id="emailpro_dashboard_diag_a_tooltip_title" qtlid="143251">Champ A</translation>
+   <translation id="emailpro_dashboard_diag_aaaa_label" qtlid="129823">AAAA</translation>
+   <translation id="emailpro_dashboard_diag_aaaa_tooltip_error" qtlid="209164">Si votre domaine est hébergé chez OVH, veuillez créer le champs AAAA en sélectionnant le nom de domaine concerné, ensuite "Mode expert" -> "Zone DNS" -> "Ajouter une entrée". Saisissez : <br /> Type de champ : <span class="bold">AAAA</span> <br /> Sous domaine : <span class="bold">{0}</span> <br /> Cible : <span class="bold">{1}</span> <br /><br /> Si votre domaine est hébergé ailleurs, alors créez le champ AAAA sur ce domaine depuis le manager de votre fournisseur en donnant les mêmes informations que ci-dessus.</translation>
+   <translation id="emailpro_dashboard_diag_aaaa_tooltip_ok" qtlid="137491">Configuration automatique effectuée</translation>
+   <translation id="emailpro_dashboard_diag_aaaa_tooltip_title" qtlid="143277">Champ AAAA IPv6</translation>
+   <translation id="emailpro_dashboard_diag_ptr_label" qtlid="143303">PTR</translation>
+   <translation id="emailpro_dashboard_diag_ptr_tooltip_error" qtlid="143316">La résolution inverse de votre adresse IP présente un problème. Veuillez contacter le support.</translation>
+   <translation id="emailpro_dashboard_diag_ptr_tooltip_ok" qtlid="137491">Configuration automatique effectuée</translation>
+   <translation id="emailpro_dashboard_diag_ptr_tooltip_title" qtlid="143303">PTR</translation>
+   <translation id="emailpro_dashboard_diag_ptrv6_label" qtlid="143329">PTR v6</translation>
+   <translation id="emailpro_dashboard_diag_ptrv6_tooltip_error" qtlid="143342">La résolution inverse de votre adresse IPv6 présente un problème. Veuillez contacter le support.</translation>
+   <translation id="emailpro_dashboard_diag_ptrv6_tooltip_ok" qtlid="137491">Configuration automatique effectuée</translation>
+   <translation id="emailpro_dashboard_diag_ptrv6_tooltip_title" qtlid="143329">PTR v6</translation>
+   <translation id="emailpro_dashboard_display_name_min" qtlid="177925">Opération annulée. Minimum 5 caractères requises</translation>
+   <translation id="emailpro_dashboard_domains" qtlid="276298">Domaines associés</translation>
+   <translation id="emailpro_dashboard_expiration" qtlid="168172">Renouvellement</translation>
+   <translation id="emailpro_dashboard_guides_url" qtlid="156732">Consultez nos guides en ligne.</translation>
+   <translation id="emailpro_dashboard_loading_error" qtlid="168120">Une erreur s'est produite lors du chargement des informations.</translation>
+   <translation id="emailpro_dashboard_message_see_more" qtlid="91645">Voir les détails</translation>
+   <translation id="emailpro_dashboard_name" qtlid="136165">Référence serveur</translation>
+   <translation id="emailpro_dashboard_new_window" qtlid="222176">Nouvelle fenêtre</translation>
+   <translation id="emailpro_dashboard_ssl_expiration" qtlid="190797">Expiration SSL</translation>
+   <translation id="emailpro_dashboard_tasks" qtlid="136217">Tâches récentes</translation>
+
+
+   <translation id="emailpro_resilitation_action_button" qtlid="48646">Résilier</translation>
+   <translation id="emailpro_resilitation_action_button_cancel" qtlid="211567">Annuler la resiliation</translation>
+   <translation id="emailpro_resilitation_action_hosted_warning" qtlid="209073">Vos comptes seront suspendus à échéance.</translation>
+   <translation id="emailpro_resilitation_action_partial" qtlid="191031">Une partie des changements de la période de renouvellement sont en erreur.</translation>
+   <translation id="emailpro_resilitation_cancel_action_button" qtlid="4070">Continuer</translation>
+   <translation id="emailpro_resilitation_cancel_action_confirmation" qtlid="201380">Vous êtes sur le point d'annuler la résiliation du service "{0}". <br />Souhaitez-vous procéder à cette opération ? <br /> Le service passera alors en renouvellement automatique.</translation>
+   <translation id="emailpro_resilitation_cancel_action_failure" qtlid="211580">Une erreur est survenue lors de l'annulation de suppression de votre service.</translation>
+   <translation id="emailpro_resilitation_cancel_action_partial" qtlid="191031">Une partie des changements de la période de renouvellement sont en erreur.</translation>
+   <translation id="emailpro_tab_ACCOUNTS_error_message" qtlid="143915">Une erreur est survenue lors du chargement de vos comptes.</translation>
+
+   <translation id="emailpro_tab_ACCOUNTS_menu_account_tooltip" qtlid="19075">Plus d'actions</translation>
+   <translation id="emailpro_tab_ACCOUNTS_partial" qtlid="143889">Certains comptes n'ont pu être chargés correctement. Veuillez rafraîchir la page afin de résoudre le problème.</translation>
+   <translation id="emailpro_tab_ACCOUNTS_partial_account" qtlid="139208">Ce compte n'a pas été chargé correctement.</translation>
+   <translation id="emailpro_tab_ACCOUNTS_popover_alias" qtlid="21499">Configurer les alias</translation>
+   <translation id="emailpro_tab_ACCOUNTS_popover_delegation" qtlid="143434">Configurer les délégations</translation>
+   <translation id="emailpro_tab_ACCOUNTS_popover_span_text" qtlid="277689">L'envoi d'e-mail à partir de ce compte a été bloqué pour cause de SPAM. <br />Afin de débloquer ce compte, il est nécessaire de répondre au ticket en attente.<br /><br /><a href="{0}" class="link pull-right">Répondre au ticket</a><br /></translation>
+   <translation id="emailpro_tab_ACCOUNTS_popover_span_title" qtlid="277676">Compte bloqué SPAM</translation>
+   <translation id="emailpro_tab_ACCOUNTS_pwderror" qtlid="137296">Confirmation incorrecte</translation>
+   <translation id="emailpro_tab_ACCOUNTS_state_CREATING" qtlid="146632">Création en cours</translation>
+   <translation id="emailpro_tab_ACCOUNTS_state_DELETING" qtlid="146645">Suppression en cours</translation>
+   <translation id="emailpro_tab_ACCOUNTS_state_TASK_ON_DOING" qtlid="485632">Tâche planifiée ou en cours d'exécution</translation>
+   <translation id="emailpro_tab_ACCOUNTS_state_TASK_ON_ERROR" qtlid="485788">Tâche en erreur</translation>
+   <translation id="emailpro_tab_ACCOUNTS_table_alias" qtlid="9466">Alias</translation>
+   <translation id="emailpro_tab_ACCOUNTS_table_email" qtlid="137244">Compte e-mail</translation>
+   <translation id="emailpro_tab_ACCOUNTS_table_empty" qtlid="149800">Vous n'avez pas de compte</translation>
+   <translation id="emailpro_tab_ACCOUNTS_table_empty_type_BASIC" qtlid="190810">Vous n'avez pas de compte de type Basic</translation>
+   <translation id="emailpro_tab_ACCOUNTS_table_empty_type_STANDARD" qtlid="190823">Vous n'avez pas de compte de type Standard</translation>
+   <translation id="emailpro_tab_ACCOUNTS_table_empty_type_ENTERPRISE" qtlid="190836">Vous n'avez pas de compte de type Entreprise</translation>
+   <translation id="emailpro_tab_ACCOUNTS_table_empty_search" qtlid="149813">Vous n'avez pas de compte correspondant au terme recherché</translation>
+   <translation id="emailpro_tab_ACCOUNTS_table_size" qtlid="7726">Taille</translation>
+   <translation id="emailpro_tab_ACCOUNTS_table_status" qtlid="26443">Statut</translation>
+   <translation id="emailpro_tab_ACCOUNTS_table_type" qtlid="2642">Type</translation>
+   <translation id="emailpro_tab_ACCOUNTS_type_ALL" qtlid="69173">Tous</translation>
+   <translation id="emailpro_tab_ACCOUNTS_type_BASIC" qtlid="48986">Basic</translation>
+   <translation id="emailpro_tab_ACCOUNTS_type_STANDARD" qtlid="48998">Standard</translation>
+   <translation id="emailpro_tab_ACCOUNTS_type_ENTERPRISE" qtlid="49022">Entreprise</translation>
+   <translation id="emailpro_tab_ACCOUNTS_warning" qtlid="108456">Attention !</translation>
+
+   <translation id="emailpro_tab_ALIAS_add_alias_error_message" qtlid="143681">Une erreur est survenue lors de la création de votre alias.</translation>
+   <translation id="emailpro_tab_ALIAS_add_alias_intro" qtlid="416579">Créer un alias pour le compte <span class="bold">{0}</span></translation>
+   <translation id="emailpro_tab_ALIAS_add_alias_placeholder" qtlid="9466">Alias</translation>
+   <translation id="emailpro_tab_ALIAS_add_alias_step2_account_label" qtlid="143603">Compte attaché</translation>
+   <translation id="emailpro_tab_ALIAS_add_alias_step2_alias_label" qtlid="9466">Alias</translation>
+   <translation id="emailpro_tab_ALIAS_add_alias_step2_intro" qtlid="144006">Etes-vous sûr de vouloir ajouter l’alias ci-dessous ?</translation>
+   <translation id="emailpro_tab_ALIAS_add_alias_success_message" qtlid="144032">L’alias va être ajouté.</translation>
+   <translation id="emailpro_tab_ALIAS_add_alias_title" qtlid="143616">Créer un alias</translation>
+   <translation id="emailpro_tab_ALIAS_add_alias_valid" qtlid="171747">Attention, certains caractères spéciaux ne sont pas acceptés dans le nom d'un alias, par exemple + ? / () [] ;</translation>
+   <translation id="emailpro_tab_ALIAS_add_button" qtlid="143538">Ajouter un alias</translation>
+   <translation id="emailpro_tab_ALIAS_delete_error_message" qtlid="143577">Une erreur est survenue lors de la suppression de votre alias.</translation>
+   <translation id="emailpro_tab_ALIAS_delete_success_message" qtlid="143564">Votre alias va être supprimé.</translation>
+   <translation id="emailpro_tab_ALIAS_delete_tooltip" qtlid="178848">Supprimer cet alias</translation>
+   <translation id="emailpro_tab_ALIAS_domain_loading_failure" qtlid="144045">Une erreur est survenue lors du chargement de vos domaines.</translation>
+   <translation id="emailpro_tab_ALIAS_error_message" qtlid="143980">Une erreur est survenue lors du chargement de vos alias.</translation>
+   <translation id="emailpro_tab_ALIAS_header" qtlid="9466">Alias</translation>
+   <translation id="emailpro_tab_ALIAS_remove_account_label" qtlid="143603">Compte attaché</translation>
+   <translation id="emailpro_tab_ALIAS_remove_alias_label" qtlid="9466">Alias</translation>
+   <translation id="emailpro_tab_ALIAS_remove_alias_title" qtlid="9550">Supprimer un alias</translation>
+   <translation id="emailpro_tab_ALIAS_state_TASK_ON_DOING" qtlid="26383">En cours</translation>
+   <translation id="emailpro_tab_ALIAS_state_TASK_ON_DOING_tooltip" qtlid="143967">Une tâche concernant cet alias est planifiée ou en cours d'exécution</translation>
+   <translation id="emailpro_tab_ALIAS_state_TASK_ON_DOING_tooltip" qtlid="143967">Une tâche concernant cet alias est planifiée ou en cours d'exécution</translation>
+   <translation id="emailpro_tab_ALIAS_taken_error_message" qtlid="190849">Adresse email déjà existante.</translation>
+
+   <translation id="emailpro_tab_DISCLAIMER" qtlid="276324">Pieds de page</translation>
+   <translation id="emailpro_tab_DISCLAIMER_table_empty" qtlid="152258">Vous n'avez pas de signature.</translation>
+   <translation id="emailpro_tab_DISCLAIMER_associated_domains" qtlid="133110">Domaine associé</translation>
+   <translation id="emailpro_tab_DISCLAIMER_disclaimer_content" qtlid="152271">Contenu</translation>
+   <translation id="emailpro_tab_DISCLAIMER_disclaimer_outside_only" qtlid="152284">Externe uniquement</translation>
+   <translation id="emailpro_tab_DISCLAIMER_disclaimer_outside_only_false" qtlid="34788">Non</translation>
+   <translation id="emailpro_tab_DISCLAIMER_disclaimer_outside_only_tooltip" qtlid="152297">Signature utilisée uniquement pour les envois vers l'extérieur</translation>
+   <translation id="emailpro_tab_DISCLAIMER_disclaimer_outside_only_true" qtlid="34776">Oui</translation>
+   <translation id="emailpro_tab_DISCLAIMER_error_message" qtlid="152245">Une erreur est survenue lors du chargement des signatures.</translation>
+   <translation id="emailpro_tab_DISCLAIMER_menu_delete" qtlid="2414">Supprimer</translation>
+   <translation id="emailpro_tab_DISCLAIMER_menu_settings" qtlid="37875">Modifier</translation>
+   <translation id="emailpro_tab_DISCLAIMER_state_doing_tooltip" qtlid="143863">Une tâche est planifiée ou en cours d'exécution</translation>
+   <translation id="emailpro_tab_DISCLAIMER_state_header" qtlid="26443">Statut</translation>
+   <translation id="emailpro_tab_DISCLAIMER_table_no_domain" qtlid="152310">Ajoutez un domaine et attendez qu'il soit validé pour créer une signature.</translation>
+
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_fail" qtlid="171461">Une erreur est survenue lors de la demande d'ajout du contact externe.</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_display_name_label" qtlid="23515">Nom à afficher</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_email_invalid" qtlid="171370">L'adresse email entrée est invalide</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_email_label" qtlid="137244">Compte e-mail</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_first_name_label" qtlid="23323">Prénom</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_last_name_label" qtlid="3818">Nom</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_organization2010_label" qtlid="32278">Organisation</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_question" qtlid="171357">Vous allez créer un contact externe</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_wizardhelp_requirements_content" qtlid="174659">Les contacts externes doivent respecter les exigences suivantes :<br/><br/>- Le prénom et le nom doivent comporter au plus 64 caractères.<br/>- Le nom à afficher doit comporter au plus 255 caractères.</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step1_wizardhelp_requirements_title" qtlid="171383">Conditions sur les contacts externes</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step2_display_name_label" qtlid="23515">Nom à afficher</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step2_email_label" qtlid="137244">Compte e-mail</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step2_first_name_label" qtlid="23323">Prénom</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step2_last_name_label" qtlid="3818">Nom</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_step2_question" qtlid="171435">Souhaitez-vous réellement ajouter le contact externe suivant ?</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_success" qtlid="171448">La demande d'ajout d'un contact externe a bien été prise en compte. Elle sera effective sous quelques minutes.</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_title" qtlid="136334">Ajouter un contact externe</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_add_title_button" qtlid="136334">Ajouter un contact externe</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_delete_fail" qtlid="171591">Une erreur est survenue lors de la demande de suppression du contact externe.</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_delete_step1_contact" qtlid="171565">Contact externe :</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_delete_step1_question" qtlid="171552">Souhaitez-vous réellement supprimer le contact externe suivant ?</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_delete_success" qtlid="171578">La demande de supression du contact externe a bien été prise en compte. Elle sera effective sous quelques minutes.</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_delete_title" qtlid="171539">Supprimer un contact externe</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_fail" qtlid="171526">Une erreur est survenue lors de la demande de modification du contact externe.</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_display_name_label" qtlid="23515">Nom à afficher</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_email_invalid" qtlid="171370">L'adresse email entrée est invalide</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_email_label" qtlid="137244">Compte e-mail</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_first_name_label" qtlid="23323">Prénom</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_last_name_label" qtlid="3818">Nom</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_question" qtlid="171487">Vous allez modifier un contact externe</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_wizardhelp_requirements_content" qtlid="174659">Les contacts externes doivent respecter les exigences suivantes :<br/><br/>- Le prénom et le nom doivent comporter au plus 64 caractères.<br/>- Le nom à afficher doit comporter au plus 255 caractères.</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step1_wizardhelp_requirements_title" qtlid="171383">Conditions sur les contacts externes</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step2_display_name_label" qtlid="23515">Nom à afficher</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step2_email_label" qtlid="137244">Compte e-mail</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step2_first_name_label" qtlid="23323">Prénom</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step2_last_name_label" qtlid="3818">Nom</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_step2_question" qtlid="171500">Souhaitez-vous réellement modifier le contact externe suivant ?</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_success" qtlid="171513">La demande de modification d'un contact externe a bien été prise en compte. Elle sera effective sous quelques minutes.</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_configuration_contact_modify_title" qtlid="171474">Modifier un contact externe</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_search_placeholder" qtlid="171344">Rechercher des contacts</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_actions_menu_delete" qtlid="2414">Supprimer</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_actions_menu_modify" qtlid="37875">Modifier</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_empty" qtlid="171331">Vous n'avez aucun contact externe configuré</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_headers_creationDate" qtlid="4358">Créé le</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_headers_displayName" qtlid="80922">Nom affiché</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_headers_externalEmailAddress" qtlid="30430">Adresse</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_headers_hiddenFromGAL" qtlid="28483">Annuaire</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_headers_state" qtlid="26443">Statut</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_headers_state_CREATING" qtlid="26227">En création</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_headers_state_DELETING" qtlid="133929">En suppression</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_headers_state_REOPENING" qtlid="171279">En réouverture</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_headers_state_SUSPENDED" qtlid="136100">Suspendu</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_headers_state_SUSPENDING" qtlid="171292">En suspension</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_headers_state_MODIFYING" qtlid="174646">En modification</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_headers_state_OK" qtlid="433745">Ok</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_headers_state_MODIFYING" qtlid="174646">En modification</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_tooltip_GAL_false" qtlid="184906">L'adresse paraît dans Outlook</translation>
+   <translation id="emailpro_tab_EXTERNAL_CONTACTS_table_tooltip_GAL_true" qtlid="184919">L'adresse ne paraît pas dans Outlook</translation>
+
+   <translation id="emailpro_tab_GROUPS_error_message" qtlid="150138">Une erreur est survenue lors du chargement de vos groupes.</translation>
+
+   <translation id="emailpro_tab_INFORMATIONS_connexion" qtlid="55925">Connexion</translation>
+   <translation id="emailpro_tab_INFORMATIONS_messaging" qtlid="276363">Client de messagerie</translation>
+   <translation id="emailpro_tab_INFORMATIONS_service_url" qtlid="319414">Voir les informations du SharePoint associé</translation>
+   <translation id="emailpro_tab_INFORMATIONS_sharepoint" qtlid="319401">SharePoint associé</translation>
+   <translation id="emailpro_tab_INFORMATIONS_sharepoint_url" qtlid="297930">URL consultation</translation>
+   <translation id="emailpro_tab_INFORMATIONS_stats" qtlid="26671">Statistiques</translation>
+   <translation id="emailpro_tab_INFORMATIONS_summary" qtlid="4082">Résumé</translation>
+   <translation id="emailpro_tab_INFORMATIONS_wait_activation" qtlid="297943">En attente d'activation</translation>
+   <translation id="emailpro_tab_INFORMATIONS_webmail" qtlid="485697">Webmail :</translation>
+
+   <translation id="emailpro_tab_TASKS" qtlid="136217">Tâches récentes</translation>
+   <translation id="emailpro_tab_TASKS_table_empty" qtlid="144058">Vous n'avez pas de tâches</translation>
+   <translation id="emailpro_tab_TASKS_table_function" qtlid="61872">Tâche</translation>
+   <translation id="emailpro_tab_TASKS_table_state" qtlid="167912">Statut</translation>
+   <translation id="emailpro_tab_TASKS_DOING" qtlid="26383">En cours</translation>
+   <translation id="emailpro_tab_TASKS_CANCELLED" qtlid="27631">Annulé</translation>
+   <translation id="emailpro_tab_TASKS_DONE" qtlid="8662">Terminé</translation>
+   <translation id="emailpro_tab_TASKS_ERROR" qtlid="45508">En erreur</translation>
+   <translation id="emailpro_tab_TASKS_TODO" qtlid="37455">Planifié</translation>
+   <translation id="emailpro_tab_TASKS_ADD_ACCOUNT" qtlid="137309">Ajout de compte</translation>
+   <translation id="emailpro_tab_TASKS_ADD_ALIAS" qtlid="144071">Ajout d’alias</translation>
+   <translation id="emailpro_tab_TASKS_ADD_DOMAIN" qtlid="137335">Ajout de domaine</translation>
+   <translation id="emailpro_tab_TASKS_ADD_DOMAIN_DISCLAIMER" qtlid="152206">Ajouter une signature</translation>
+   <translation id="emailpro_tab_TASKS_ADD_EXTERNAL_CONTACT" qtlid="137348">Ajout de contact externe</translation>
+   <translation id="emailpro_tab_TASKS_ADD_FULL_ACCESS" qtlid="137361">Ajout de droits d’accès</translation>
+   <translation id="emailpro_tab_TASKS_addFullAccess" qtlid="137361">Ajout de droits d’accès</translation>
+   <translation id="emailpro_tab_TASKS_ADD_SEND_AS" qtlid="181370">Ajout de droits d'envois pour compte</translation>
+   <translation id="emailpro_tab_TASKS_CHANGE_PASSWORD" qtlid="16721">Changement mot de passe</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_ACCOUNT" qtlid="136516">Suppression compte</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_ALIAS" qtlid="136529">Suppression alias</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_DOMAIN" qtlid="136542">Suppression domaine</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_EXTERNAL_CONTACT" qtlid="137387">Suppression contact externe</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_FULL_ACCESS" qtlid="137400">Suppression droits d’accès</translation>
+   <translation id="emailpro_tab_TASKS_deleteFullAccess" qtlid="137400">Suppression droits d’accès</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_SEND_AS" qtlid="181383">Suppression droits d'envoi pour compte</translation>
+   <translation id="emailpro_tab_TASKS_UPDATE_ACCOUNT" qtlid="136594">Modification compte</translation>
+   <translation id="emailpro_tab_TASKS_SET_ACCOUNT" qtlid="136594">Modification compte</translation>
+   <translation id="emailpro_tab_TASKS_SET_DNS" qtlid="149826">Modification du DNS</translation>
+   <translation id="emailpro_tab_TASKS_INSTALL_SSL" qtlid="149839">Installation du certificat SSL</translation>
+   <translation id="emailpro_tab_TASKS_CONFIGURE_EXCHANGE_CUSTOMER" qtlid="143355">Configuration de serveur</translation>
+   <translation id="emailpro_tab_TASKS_ADD_DISTRIBUTION_GROUP" qtlid="149865">Ajout d’un groupe</translation>
+   <translation id="emailpro_tab_TASKS_addDistributionGroup" qtlid="149865">Ajout d’un groupe</translation>
+   <translation id="emailpro_tab_TASKS_ADD_DISTRIBUTION_GROUP_MANAGER" qtlid="149878">Ajout d’un administrateur de groupe</translation>
+   <translation id="emailpro_tab_TASKS_addDistributionGroupManager" qtlid="149878">Ajout d’un administrateur de groupe</translation>
+   <translation id="emailpro_tab_TASKS_ADD_DISTRIBUTION_GROUP_MEMBER" qtlid="149891">Ajout d’un contact du groupe</translation>
+   <translation id="emailpro_tab_TASKS_addDistributionGroupMember" qtlid="149891">Ajout d’un contact du groupe</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_DISTRIBUTION_GROUP" qtlid="149904">Suppression du groupe</translation>
+   <translation id="emailpro_tab_TASKS_deleteDistributionGroup" qtlid="149904">Suppression du groupe</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_DISTRIBUTION_GROUP_MANAGER" qtlid="149917">Suppression d’un administrateur du groupe</translation>
+   <translation id="emailpro_tab_TASKS_deleteDistributionGroupManager" qtlid="149930">Suppression d’un administrateur de groupe</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_DISTRIBUTION_GROUP_MEMBER" qtlid="149943">Suppression d’un contact du groupe</translation>
+   <translation id="emailpro_tab_TASKS_deleteDistributionGroupMember" qtlid="149956">Suppression contact groupe</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_DISTRIBUTION_GROUP_SEND_ON_BEHALF_TO" qtlid="180226">Suppression droits d'envoi de la part</translation>
+   <translation id="emailpro_tab_TASKS_SET_DISTRIBUTION_GROUP" qtlid="149969">Modification du groupe</translation>
+   <translation id="emailpro_tab_TASKS_setDistributionGroup" qtlid="149969">Modification du groupe</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_DOMAIN_DISCLAIMER" qtlid="152219">Supprimer une signature</translation>
+   <translation id="emailpro_tab_TASKS_SET_DOMAIN_DISCLAIMER" qtlid="152232">Modifier une signature</translation>
+   <translation id="emailpro_tab_TASKS_GENERATE_OUTLOOK_URL" qtlid="150021">Génération d’un lien Outlook</translation>
+   <translation id="emailpro_tab_TASKS_SET_DOMAIN" qtlid="136607">Modification domaine</translation>
+   <translation id="emailpro_tab_TASKS_SET_ALIAS" qtlid="148214">Modification alias</translation>
+   <translation id="emailpro_tab_TASKS_ADD_RESOURCE_ACCOUNT" qtlid="156134">Ajout compte de ressource</translation>
+   <translation id="emailpro_tab_TASKS_ADD_RESOURCE_DELEGATE" qtlid="195126">Ajout de droits pour ressource</translation>
+   <translation id="emailpro_tab_TASKS_SET_RESOURCE_ACCOUNT" qtlid="156147">Modification compte de ressource</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_RESOURCE_DELEGATE" qtlid="209086">Suppression de droits pour ressource</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_RESOURCE_ACCOUNT" qtlid="156160">Suppression compte de ressource</translation>
+   <translation id="emailpro_tab_TASKS_SET_EXTERNAL_CONTACT" qtlid="177938">Modification contact externe</translation>
+   <translation id="emailpro_tab_TASKS_ADD_SEND_ON_BEHALF_TO" qtlid="181396">Ajout de droits d'envoyer de la part pour compte</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_SEND_ON_BEHALF_TO" qtlid="181409">Suppression droits d'envoyer de la part pour compte</translation>
+   <translation id="emailpro_tab_TASKS_ADD_DISTRIBUTION_GROUP_SEND_ON_BEHALF_TO" qtlid="181422">Ajout de droits d'envoyer de la part pour groupes</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_DISTRIBUTION_GROUP_SEND_ON_BEHALF_TO" qtlid="181435">Suppression droits d'envoyer de la part pour groupes</translation>
+   <translation id="emailpro_tab_TASKS_ADD_DISTRIBUTION_GROUP_SEND_AS" qtlid="181448">Ajout de droits d'envoi pour groupes</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_DISTRIBUTION_GROUP_SEND_AS" qtlid="181461">Suppression de droits d'envoi pour groupes</translation>
+   <translation id="emailpro_tab_TASKS_ADD_EXPORT_PST_REQUEST" qtlid="190862">Vérification fichier .pst</translation>
+   <translation id="emailpro_tab_TASKS_GENERATE_PST_URL" qtlid="190875">Génération fichier .pst</translation>
+   <translation id="emailpro_tab_TASKS_SET_PUBLIC_FOLDER_PERMISSION" qtlid="201250">Modification droits pour partage</translation>
+   <translation id="emailpro_tab_TASKS_ADD_PUBLIC_FOLDER_PERMISSION" qtlid="201263">Ajout de droits pour partage</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_PUBLIC_FOLDER_PERMISSION" qtlid="201276">Suppression de droits pour partage</translation>
+   <translation id="emailpro_tab_TASKS_ADD_PUBLIC_FOLDER" qtlid="201289">Ajout partage</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_PUBLIC_FOLDER" qtlid="201302">Suppression partage</translation>
+   <translation id="emailpro_tab_TASKS_SET_PUBLIC_FOLDER" qtlid="201315">Modification partage</translation>
+   <translation id="emailpro_tab_TASKS_EXPAND_DRIVE" qtlid="191759">Ajout espace disque</translation>
+   <translation id="emailpro_tab_TASKS_ADD_SHARED_ACCOUNT" qtlid="215208">Ajout compte partagé</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_SHARED_ACCOUNT" qtlid="215221">Suppression compte partagé</translation>
+   <translation id="emailpro_tab_TASKS_SET_SHARED_ACCOUNT" qtlid="215234">Modification compte partagé</translation>
+   <translation id="emailpro_tab_TASKS_ADD_SHARED_ACCOUNT_FULL_ACCESS" qtlid="215247">Ajout de droits d’accès pour compte partagé</translation>
+   <translation id="emailpro_tab_TASKS_ADD_SHARED_ACCOUNT_SEND_AS" qtlid="215260">Ajout de droits d'envoi pour compte partagé</translation>
+   <translation id="emailpro_tab_TASKS_ADD_SHARED_ACCOUNT_SEND_ON_BEHALF_TO" qtlid="215273">Ajout de droits d'envoyer de la part pour compte partagé</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_SHARED_ACCOUNT_FULL_ACCESS" qtlid="215286">Suppression de droits d’accès pour compte partagé</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_SHARED_ACCOUNT_SEND_AS" qtlid="215299">Suppression de droits d'envoi pour compte partagé</translation>
+   <translation id="emailpro_tab_TASKS_DELETE_SHARED_ACCOUNT_SEND_ON_BEHALF_TO" qtlid="215312">Suppression de droits d'envoyer de la part pour compte partagé</translation>
+   <translation id="emailpro_tab_TASKS_table_start_date" qtlid="201328">Début</translation>
+   <translation id="emailpro_tab_TASKS_table_finish_date" qtlid="201341">Fin</translation>
+   <translation id="emailpro_tab_TASKS_warning" qtlid="136347">Attention!</translation>
+   <translation id="emailpro_tab_TASKS_partial" qtlid="137426">La liste affichée n'est pas complète, certaines tâches n'ont pu être chargées correctement.</translation>
+   <translation id="emailpro_tab_TASKS_error_message" qtlid="144097">Une erreur est survenue lors du chargement des tâches.</translation>
+   <translation id="emailpro_tab_TASKS_SET_SERVICE" qtlid="174841">Politique de sécurité des comptes</translation>
+
+   <translation id="emailpro_tab_domain_no_domain_attached" qtlid="271361">Votre service Exchange est presque prêt. Vous devez attacher un domaine à votre service. Si vous n'en avez pas, <a href="https://www.ovh.com/fr/cgi-bin/newOrder/order.cgi" target="_blank">cliquez ici</a> pour en acheter un.</translation>
+   <translation id="emailpro_tab_domain_no_domains_1" qtlid="137439">Ajoutez un domaine afin de créer des comptes e-mail Exchange. Cliquez</translation>
+   <translation id="emailpro_tab_domain_no_domains_2" qtlid="137452">ici</translation>
+   <translation id="emailpro_tab_domain_no_domains_3" qtlid="137465">pour ajouter un nouveau domaine.</translation>
+   <translation id="emailpro_tab_domain_table_empty_search" qtlid="150034">Vous n'avez pas de domaine correspondant au terme recherché</translation>
+   <translation id="emailpro_tab_domain_search" qtlid="136633">Rechercher un domaine</translation>
+   <translation id="emailpro_tab_domain_domain" qtlid="170434">Domaine</translation>
+   <translation id="emailpro_tab_domain_type" qtlid="15713">Mode</translation>
+   <translation id="emailpro_tab_domain_accounts_count" qtlid="28363">Comptes</translation>
+   <translation id="emailpro_tab_domain_popover_delete" qtlid="210267">Supprimer ce domaine</translation>
+   <translation id="emailpro_tab_domain_popover_update" qtlid="4406">Configuration</translation>
+   <translation id="emailpro_tab_domain_diagnostic" qtlid="95059">Diagnostic</translation>
+   <translation id="emailpro_tab_domain_diagnostic_mx" qtlid="23779">MX</translation>
+   <translation id="emailpro_tab_domain_diagnostic_mx_title" qtlid="137478">Diagnostic MX</translation>
+   <translation id="emailpro_tab_domain_diagnostic_mx_toolbox_ok" qtlid="137491">Configuration automatique effectuée</translation>
+   <translation id="emailpro_tab_domain_diagnostic_mx_intro_ovh" qtlid="192890">Votre domaine est hébergé chez OVH, vous pouvez configurer le champ MX de votre domaine {0} de la manière suivante</translation>
+   <translation id="emailpro_tab_domain_diagnostic_mx_label_champ" qtlid="192903">Champ MX</translation>
+   <translation id="emailpro_tab_domain_diagnostic_mx_label_champs" qtlid="46780">Champs MX</translation>
+   <translation id="emailpro_tab_domain_diagnostic_mx_no_antispam" qtlid="447664">Si vous utilisez le mode non-autoritatif (Exchange + autre système de messagerie) avec un système de messagerie non hébergé par OVH :</translation>
+   <translation id="emailpro_tab_domain_diagnostic_mx_no_antispam_config" qtlid="192929">Priorité : <strong>{0}</strong>; cible : <strong>{1}</strong></translation>
+   <translation id="emailpro_tab_domain_diagnostic_mx_antispam" qtlid="447677">Si vous utilisez le mode autoritatif (Exchange uniquement) ou non-autoritatif avec un système de messagerie hébergé (e-mail mutualisé) par OVH :</translation>
+   <translation id="emailpro_tab_domain_diagnostic_mx_antispam_config" qtlid="192955">Priorité : <strong>{0}</strong>; cible : <strong>{1}</strong><br /> Priorité : <strong>{2}</strong>; cible : <strong>{3}</strong><br /> Priorité : <strong>{4}</strong>; cible : <strong>{5}</strong><br /> Priorité : <strong>{6}</strong>; cible : <strong>{7}</strong><br /></translation>
+   <translation id="emailpro_tab_domain_diagnostic_mx_no_ovh" qtlid="349101">Si le domaine n'est pas géré par le même identifiant client que le service Exchange ou si votre domaine n'est pas hébergé chez OVH, la configuration automatique n'est pas possible. Veuillez créer le champ MX sur ce domaine manuellement en donnant les mêmes informations que ci-dessous.</translation>
+   <translation id="emailpro_tab_domain_diagnostic_mx_recap" qtlid="192981">Un champ MX va être ajouté dans la zone DNS de votre domaine. Attention, les champs MX pre-existants vont être effacés.</translation>
+   <translation id="emailpro_tab_domain_diagnostic_add_field_success" qtlid="316905">La modification de la zone DNS a été effectuée. La propagation de l'information et la mise à jour de diagnostic peuvent prendre plusieurs heures.</translation>
+   <translation id="emailpro_tab_domain_diagnostic_add_field_failure" qtlid="193007">Une erreur est survenue lors de la modification de votre zone DNS.</translation>
+   <translation id="emailpro_tab_domain_diagnostic_srv_intro_ovh" qtlid="193020">Votre domaine est hébergé chez OVH, vous pouvez configurer le champ SRV de votre domaine {0} de la manière suivante</translation>
+   <translation id="emailpro_tab_domain_diagnostic_srv_label_champ" qtlid="193033">Champ SRV</translation>
+   <translation id="emailpro_tab_domain_diagnostic_srv_config" qtlid="193046">Sous domaine : <strong>{0}</strong><br /> Priorité : <strong>{1}</strong><br /> Poids : <strong>{2}</strong><br /> Port : <strong>{3}</strong><br /> Cible : <strong>{4}</strong></translation>
+   <translation id="emailpro_tab_domain_diagnostic_srv_no_ovh" qtlid="349114">Si le domaine n'est pas géré par le même identifiant client que le service Exchange ou si votre domaine n'est pas hébergé chez OVH, la configuration automatique n'est pas possible. Veuillez créer le champ SRV sur ce domaine manuellement en donnant les mêmes informations que ci-dessous.</translation>
+   <translation id="emailpro_tab_domain_diagnostic_srv_recap" qtlid="256191">Un champ SRV va être ajouté dans la zone DNS de votre domaine. Attention, les champs SRV pré-existants avec sous-domaine "{0}" vont être effacés.</translation>
+   <translation id="emailpro_tab_domain_diagnostic_srv" qtlid="130003">SRV</translation>
+   <translation id="emailpro_tab_domain_diagnostic_srv_title" qtlid="137517">Diagnostic SRV</translation>
+   <translation id="emailpro_tab_domain_diagnostic_srv_toolbox_ok" qtlid="137491">Configuration automatique effectuée</translation>
+   <translation id="emailpro_tab_domain_error_message" qtlid="144045">Une erreur est survenue lors du chargement de vos domaines.</translation>
+   <translation id="emailpro_tab_domain_diagnostic_cname" qtlid="129847">CNAME</translation>
+   <translation id="emailpro_tab_domain_status" qtlid="26443">Statut</translation>
+   <translation id="emailpro_tab_domain_task_in_progress" qtlid="2690">Tâche en cours</translation>
+   <translation id="emailpro_tab_domain_validation" qtlid="33802">Validation</translation>
+   <translation id="emailpro_tab_domain_validation_doing" qtlid="136646">Validation de domaine en cours</translation>
+   <translation id="emailpro_tab_domain_validation_cname" qtlid="139260">Merci de créer un enregistrement CNAME.</translation>
+   <translation id="emailpro_tab_domain_validation_cname_title" qtlid="139273">Vérification propriétaire</translation>
+   <translation id="emailpro_tab_domain_validation_cname_details" qtlid="363401">Afin de valider votre propriété sur ce domaine, merci de créer un enregistrement CNAME : <br /><br /><span class="bold">{0}.{1}</span> vers <span class="bold">{2}</span>.<br /><br /> Vous avez 48h pour effectuer cette opération.</translation>
+   <translation id="emailpro_tab_domain_add_domain" qtlid="8602">Ajouter un domaine</translation>
+   <translation id="emailpro_tab_domain_delete_domain" qtlid="137556">Retirer ce domaine des services Exchange</translation>
+   <translation id="emailpro_tab_domain_creating" qtlid="26791">Création</translation>
+   <translation id="emailpro_tab_domain_delete_domain_accounts_warning" qtlid="148227">Ce domaine ne peut pas être supprimé car il est encore utilisé par un ou plusieurs compte Exchange</translation>
+   <translation id="emailpro_tab_domain_NON_AUTHORITATIVE" qtlid="447703">Non-autoritatif</translation>
+   <translation id="emailpro_tab_domain_AUTHORITATIVE" qtlid="58807">Autoritatif</translation>
+   <translation id="emailpro_tab_domain_warning" qtlid="136347">Attention!</translation>
+   <translation id="emailpro_tab_domain_partial" qtlid="137569">Certains domaines n'ont pu être chargés correctement. Veuillez rafraîchir la page afin de résoudre le problème.</translation>
+   <translation id="emailpro_tab_domain_add_step1_select_domain_option" qtlid="136971">Sélectionner un domaine dans la liste</translation>
+   <translation id="emailpro_tab_domain_add_step1_user_owned_option" qtlid="397533">Saisir un nom de domaine non géré par votre compte OVH</translation>
+   <translation id="emailpro_tab_domain_add_step1_user_owned_info" qtlid="397546">Attention : vous devez vous assurer que la zone DNS du domaine choisi pourra être modifiée par son administrateur</translation>
+   <translation id="emailpro_tab_domain_add_step1_order_domain_option" qtlid="136997">Commander un nom de domaine</translation>
+   <translation id="emailpro_tab_domain_add_step1_domain_none" qtlid="434538">Aucun résultat trouvé</translation>
+   <translation id="emailpro_tab_domain_add_step3_cover_guide" qtlid="139572">Image de présentation de guide video</translation>
+   <translation id="emailpro_tab_domain_add_step1_main_domain" qtlid="191070">Domaine principal d'une organisation</translation>
+   <translation id="emailpro_tab_domain_add_step1_main_domain_tooltip" qtlid="191083">Domaine principal de l'organisation</translation>
+   <translation id="emailpro_tab_domain_add_step1_new_organization_intro" qtlid="447716">Le domaine de votre organisation va être <strong>{0}</strong></translation>
+   <translation id="emailpro_tab_domain_add_step1_new_organization_placeholder" qtlid="191109">Nom de l'organisation</translation>
+   <translation id="emailpro_tab_domain_add_step2_main_domain" qtlid="191122">Domaine principal</translation>
+   <translation id="emailpro_tab_domain_add_step2_organization" qtlid="32278">Organisation</translation>
+   <translation id="emailpro_tab_domain_add_step2_main_domain_true" qtlid="34776">Oui</translation>
+   <translation id="emailpro_tab_domain_add_step2_main_domain_false" qtlid="34788">Non</translation>
+   <translation id="emailpro_tab_domain_add_step2_mx_replay" qtlid="316931">Serveur e-mail cible</translation>
+   <translation id="emailpro_tab_domain_add_step2_mx_replay_tooltip" qtlid="210293">Les e-mails avec destinataires non trouvés seront redirigés vers ce serveur</translation>
+   <translation id="emailpro_tab_domain_add_step1_attach_organization_intro" qtlid="191135">Le domaine va être inclus dans l'organisation suivante :</translation>
+   <translation id="emailpro_tab_domain_add_set_auto_display" qtlid="416488">Cochez cette case pour empêcher cette fenêtre de se rouvrir.</translation>
+   <translation id="emailpro_tab_domain_add_goToWizardButton" qtlid="449388">Je préfère utiliser <br />l'assistant de configuration</translation>
+   <translation id="emailpro_tab_domain_add_step1_order_domain_desc1" qtlid="167873">Afin de confirmer votre demande, veuillez procéder au règlement en cliquant sur le bouton "Commander" ci-dessous.</translation>
+   <translation id="emailpro_tab_domain_add_step1_order_domain_desc2" qtlid="144175">Un nouvel onglet s'ouvrira et vous serez automatiquement redirigé vers l'interface de paiement OVH.</translation>
+   <translation id="emailpro_tab_domain_step1_helpwizard_subdomain_title" qtlid="137881">Utiliser un sous-domaine</translation>
+   <translation id="emailpro_tab_domain_step1_helpwizard_subdomain" qtlid="397559">Pour ajouter un sous-domaine d'un de vos domaines OVH, vous pouvez cocher "Saisir un nom de domaine non géré par votre compte OVH" et le saisir dans le champ correspondant.</translation>
+   <translation id="emailpro_tab_domain_add_step2_which_domain_type" qtlid="137998">De quel type de domaine <span class="italic">{0}</span> s'agit-il ?</translation>
+   <translation id="emailpro_tab_domain_add_step2_auth_intro" qtlid="140859">Votre domaine <span class="italic">{0}</span> va être configuré en mode autoritatif.</translation>
+   <translation id="emailpro_tab_domain_add_step2_non_auth_intro" qtlid="447729">Votre domaine <span class="italic">{0}</span> va être configuré en mode non-autoritatif.</translation>
+   <translation id="emailpro_tab_domain_add_step2bis_intro" qtlid="316944">Sélectionnez le mode de votre domaine :</translation>
+   <translation id="emailpro_tab_domain_add_step2_srv_checkbox" qtlid="138011">Configurer automatiquement le SRV (autodiscover)</translation>
+   <translation id="emailpro_tab_domain_add_step2_mx_checkbox" qtlid="139585">Configurer automatiquement le MX (réception des e-mails)</translation>
+   <translation id="emailpro_tab_domain_add_step2_mx_tooltip" qtlid="140209">Attention, configurer automatiquement le MX peut impacter la réception des e-mails préalablement configurés sur ce nom de domaine.</translation>
+   <translation id="emailpro_tab_domain_add_step2_srv_tooltip" qtlid="447742">Cette option permettra à votre client de messagerie, comme par exemple Outlook ou Mail, de découvrir automatiquement vos paramètres de connexion.</translation>
+   <translation id="emailpro_tab_domain_add_step3_srv_confirmation" qtlid="137816">Configuration SRV</translation>
+   <translation id="emailpro_tab_domain_add_step3_mx_confirmation" qtlid="137829">Configuration MX</translation>
+   <translation id="emailpro_tab_domain_add_step3_mx_replay" qtlid="316957">Serveur e-mail cible</translation>
+   <translation id="emailpro_tab_domain_add_step3_configuration_true" qtlid="137842">Automatiquement</translation>
+   <translation id="emailpro_tab_domain_add_step3_configuration_false" qtlid="34788">Non</translation>
+   <translation id="emailpro_tab_domain_add_step3_confirmation" qtlid="137855">Etes-vous sûr de vouloir ajouter le domaine ci-dessous au serveur exchange ?</translation>
+   <translation id="emailpro_tab_domain_add_success" qtlid="137868">L'ajout du domaine à votre serveur exchange va être effectué.</translation>
+   <translation id="emailpro_tab_domain_add_failure" qtlid="137049">Une erreur est survenue lors de l'ajout du domaine à votre serveur exchange.</translation>
+   <translation id="emailpro_tab_domain_modify_success" qtlid="137907">La mise à jour du domaine va être effectuée.</translation>
+   <translation id="emailpro_tab_domain_modify_failure" qtlid="137075">Une erreur est survenue lors de la mise à jour du domaine.</translation>
+   <translation id="emailpro_tab_domain_modify_in_progress" qtlid="137088">Passage vers {0} en cours</translation>
+   <translation id="emailpro_tab_domain_inverse_NON_AUTHORITATIVE" qtlid="58807">Autoritatif</translation>
+   <translation id="emailpro_tab_domain_inverse_AUTHORITATIVE" qtlid="447755">Non-autoritatif</translation>
+   <translation id="emailpro_tab_domain_mode_AUTHORITATIVE" qtlid="316970">Autoritatif (Exchange uniquement)</translation>
+   <translation id="emailpro_tab_domain_mode_NON_AUTHORITATIVE" qtlid="447768">Non-autoritatif (Exchange + autre service de messagerie)</translation>
+   <translation id="emailpro_tab_domain_AUTHORITATIVE_info" qtlid="324847">Le mode autoritatif ne permet pas l'usage d'un autre système de messagerie avec des comptes Exchange. Ce mode permet l'activation de l'antispam Vade Secure.</translation>
+   <translation id="emailpro_tab_domain_NON_AUTHORITATIVE_info" qtlid="447781">Le mode non-autoritatif permet une cohabitation entre Exchange et un autre service de messagerie. L'antispam Vade Secure est compatible si les comptes pop/imap sont hébergés chez OVH (mxplan ou offre mutualisée), il faut indiquer dans ce cas mx1.mail.ovh.net en serveur e-mail cible.</translation>
+   <translation id="emailpro_tab_domain_target_mail_server_label" qtlid="316957">Serveur e-mail cible</translation>
+   <translation id="emailpro_tab_domain_noovh_mx_info" qtlid="317126">Les modifications MX et SRV seront à réaliser manuellement dans votre zone DNS. Vous pouvez retrouver les informations nécessaires dans la section domaines associés, une fois la validation CNAME effectuée.</translation>
+   <translation id="emailpro_tab_domain_modify_domain" qtlid="137101">Configuration domaine</translation>
+   <translation id="emailpro_tab_domain_modify_domain_tooltip" qtlid="444667">L'antispam Vade Secure est compatible avec le mode non-autoritatif (uniquement si vos comptes POP/IMAP sont hébergés par OVH). Dans ce cas, il est conseillé d'utiliser : <strong>{0}</strong>, <strong>{1}</strong>, <strong>{2}</strong> et <strong>{3}</strong><br/><br/> Si vous utilisez le mode non-autoritatif avec des comptes e-mail non hébergés par OVH, vous devez utiliser : <strong>{4}</strong> (voir section domaines associés)</translation>
+   <translation id="emailpro_tab_domain_modify_title" qtlid="137920">Etes-vous sûr de vouloir modifier le domaine suivant de votre service Exchange ?</translation>
+   <translation id="emailpro_tab_domain_modify_loop_warning" qtlid="210319">Attention, boucle infinie !</translation>
+   <translation id="emailpro_tab_domain_modify_domain_warning" qtlid="210332">Domaine invalide.</translation>
+   <translation id="emailpro_tab_domain_modify_length_warning" qtlid="210345">Attention, maximum 255 caractères !</translation>
+   <translation id="emailpro_tab_domain_modify_wizard_subtitle" qtlid="210358">Autoritatif / Non-autoritatif : Que dois-je choisir ?</translation>
+   <translation id="emailpro_tab_domain_modify_wizard_text" qtlid="370018">Par défaut, lorsque vous ajoutez votre domaine sur le serveur Exchange, il se trouve en mode autoritatif. C'est-à-dire que lorsque vous envoyez un e-mail à l'adresse du domaine géré sur le serveur, ce dernier va regarder exclusivement sur le serveur Exchange si l'adresse est présente. <br /><br /> En revanche, si vous basculez le domaine en mode non-autoritatif, lors de l'envoi du e-mail, nous allons vérifier dans un premier temps si l'adresse e-mail est présente sur le serveur Exchange, et si ce n'est pas le cas, ce dernier relayera votre message sur le serveur MX que vous avez défini. <br /><br />Le domaine en mode non-autoritatif peut être utilisé si vous souhaitez, par exemple, gérer une partie de vos e-mails sur Exchange et une autre partie sur un serveur externe. <br /><br />Attention, si vous souhaitez utiliser le service Exchange et le service e-mail mutualisé OVH, vous devez dans le champ "Serveur e-mail cible" du formulaire de gauche renseigner cette valeur : <strong>mx1.mail.ovh.net.</strong></translation>
+   <translation id="emailpro_tab_domain_remove_domain" qtlid="137933">Supprimer un domaine</translation>
+   <translation id="emailpro_tab_domain_remove_title" qtlid="137946">Etes-vous sûr de vouloir réellement supprimer le domaine suivant de votre service Exchange ?</translation>
+   <translation id="emailpro_tab_domain_remove_success" qtlid="137959">Le domaine va être supprimé de votre service Exchange.</translation>
+   <translation id="emailpro_tab_domain_remove_failure" qtlid="137972">Une erreur est survenue lors de la suppression du domaine de votre service Exchange.</translation>
+
+   <translation id="emailpro_update_billing_action_title" qtlid="98324">Période de renouvellement</translation>
+   <translation id="emailpro_update_billing_button_title" qtlid="190953">Mode de facturation</translation>
+   <translation id="emailpro_update_billing_expiration_date_label" qtlid="30406">Expiration</translation>
+   <translation id="emailpro_update_billing_header_1M" qtlid="60378">Mensuel</translation>
+   <translation id="emailpro_update_billing_header_1Y" qtlid="60390">Annuel</translation>
+   <translation id="emailpro_update_billing_header_new_periode" qtlid="190992">Nouvelle période</translation>
+   <translation id="emailpro_update_billing_header_terminate" qtlid="209177">Aucune</translation>
+   <translation id="emailpro_update_billing_periode_delete_warning" qtlid="211593">Attention! Ce choix implique que le service va expirer à terme et les données seront perdues. Il sera alors impossible de récupérer les données du compte.</translation>
+   <translation id="emailpro_update_billing_periode_failure" qtlid="191044">Une erreur est survenue lors du chargement de la période de renouvellement automatique.</translation>
+   <translation id="emailpro_update_billing_periode_intro" qtlid="190966">Choisissez la périodicité souhaitée pour le renouvellement automatique de chaque compte. <br />Celle-ci sera appliquée à partir du prochain renouvellement.</translation>
+   <translation id="emailpro_update_billing_periode_label" qtlid="168172">Renouvellement</translation>
+   <translation id="emailpro_update_billing_periode_partial" qtlid="191031">Une partie des changements de la période de renouvellement sont en erreur.</translation>
+   <translation id="emailpro_update_billing_periode_resume" qtlid="191005">Vous allez changer la période de renouvellement de vos comptes :</translation>
+   <translation id="emailpro_update_billing_periode_success" qtlid="191018">Le changement de la période de renouvellement automatique a été effectué.</translation>
+   <translation id="emailpro_update_billing_periode_value_YEARLY" qtlid="79542">annuel</translation>
+   <translation id="emailpro_update_billing_periode_value_MONTHLY" qtlid="79530">mensuel</translation>
+   <translation id="emailpro_update_billing_periode_value_DELETE_AT_EXPIRATION" qtlid="201406">Expire au terme</translation>
 </translations>


### PR DESCRIPTION
## Retrieve translations from `ovh-module-exchange`

ref: MFRWW-1126

### Description of the Change

The [ovh-module-emailpro](https://github.com/ovh-ux/ovh-module-emailpro) used some translations from [ovh-module-exchange](https://github.com/ovh-ux/ovh-module-exchange). 

I've retrieved them in this module (in [Messages_fr_FR.xml](https://github.com/ovh-ux/ovh-module-emailpro/blob/a469b11618c88aca12018787bf2d0fc70428ac00/src/resources/i18n/emailpro/Messages_fr_FR.xml)), and updated the `id` of translations (`emailpro_` instead of `exchange_`).

### Benefits

No more unreported dependencies on [ovh-module-exchange](https://github.com/ovh-ux/ovh-module-exchange).

