### PR TITLE
fix(account.order): rewording

### DIFF
--- a/src/emailpro/account/add/emailpro-account-add.controller.js
+++ b/src/emailpro/account/add/emailpro-account-add.controller.js
@@ -204,11 +204,11 @@ angular.module('Module.emailpro.controllers')
       EmailPro.getOrderList($stateParams.productId).then((data) => {
         $scope.ordersList = _.map(data, (datum) => {
           const orderAvailable = _.cloneDeep(datum);
-          orderAvailable.unitaryMonthlyPriceWithTax.localizedText = EmailPro.getLocalizedPrice(
+          orderAvailable.unitaryMonthlyPriceWithTaxes.localizedText = EmailPro.getLocalizedPrice(
             $scope.ovhSubsidiary,
             parseFloat(orderAvailable.duration.duration)
-              * orderAvailable.unitaryMonthlyPriceWithTax.value,
-            orderAvailable.unitaryMonthlyPriceWithTax.currencyCode,
+              * orderAvailable.unitaryMonthlyPriceWithTaxes.value,
+            orderAvailable.unitaryMonthlyPriceWithTaxes.currencyCode,
           );
           return orderAvailable;
         });

--- a/src/emailpro/account/order/emailpro-account-order.html
+++ b/src/emailpro/account/order/emailpro-account-order.html
@@ -32,10 +32,10 @@
                                     <span data-ng-bind-html="tr('exchange_ACTION_order_accounts_step1_pay_type_' + orderAvailable.duration.duration)"></span>
                                     (<strong>
                                         <span data-ng-if="!showPriceWithTaxOnly"
-                                              data-ng-bind="tr('emailpro_ACTION_order_accounts_step1_price', [ orderAvailable.unitaryMonthlyPrice.text, orderAvailable.unitaryMonthlyPriceWithTax.text ])">
+                                              data-ng-bind="tr('emailpro_ACTION_order_accounts_step1_price', [ orderAvailable.unitaryMonthlyPrice.text, orderAvailable.unitaryMonthlyPriceWithTaxes.text ])">
                                         </span>
                                         <span data-ng-if="showPriceWithTaxOnly"
-                                              data-ng-bind="tr('emailpro_ACTION_order_accounts_step1_price_with_tax_only', [ orderAvailable.unitaryMonthlyPriceWithTax.localizedText ])">
+                                              data-ng-bind="tr('emailpro_ACTION_order_accounts_step1_price_with_tax_only', [ orderAvailable.unitaryMonthlyPriceWithTaxes.localizedText ])">
                                         </span>
                                     </strong>
                                     <span data-ng-bind="tr('emailpro_ACTION_order_accounts_per_account')"></span>


### PR DESCRIPTION
Use `unitaryMonthlyPriceWithTaxes` (returned by the 2API) instead of `unitaryMonthlyPriceWithTax`

ref: MFRWW-497
